### PR TITLE
Add GitHub Actions workflow for package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,55 +1,44 @@
 name: Publish Package
-
 on:
   push:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   contents: write
   id-token: write
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         with:
           version: '10.14.0'
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
       - name: Type check
         run: pnpm type-check
-
       - name: Lint package.json
         run: pnpm pkgJsonLint
-
       - name: Build package
         run: pnpm build
-
       - name: Determine version bump
         id: version
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
@@ -67,17 +56,15 @@ jobs:
             chore:patch:Chores
             revert:patch:Reverts
           dry_run: true
-
       - name: Update version in package.json
         if: steps.version.outputs.new_tag
         run: |
           NEW_VERSION="${{ steps.version.outputs.new_version }}"
           echo "Updating package.json to version $NEW_VERSION"
           npm version $NEW_VERSION --no-git-tag-version
-
       - name: Generate changelog
         if: steps.version.outputs.new_tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
@@ -94,16 +81,14 @@ jobs:
             ci:patch:Continuous Integration
             chore:patch:Chores
             revert:patch:Reverts
-
       - name: Publish to npm
         if: steps.version.outputs.new_tag
         run: pnpm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Create GitHub Release
         if: steps.version.outputs.new_tag
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
         with:
           tag_name: ${{ steps.version.outputs.new_tag }}
           name: Release ${{ steps.version.outputs.new_version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,114 @@
+name: Publish Package
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10.14.0'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Lint package.json
+        run: pnpm pkgJsonLint
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Determine version bump
+        id: version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          custom_release_rules: |
+            *:patch:Patch Release
+            feat:minor:Minor Release
+            fix:patch:Patch Release
+            docs:patch:Documentation
+            style:patch:Code Style
+            refactor:patch:Code Refactoring
+            perf:patch:Performance Improvements
+            test:patch:Tests
+            build:patch:Build System
+            ci:patch:Continuous Integration
+            chore:patch:Chores
+            revert:patch:Reverts
+          dry_run: true
+
+      - name: Update version in package.json
+        if: steps.version.outputs.new_tag
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          echo "Updating package.json to version $NEW_VERSION"
+          npm version $NEW_VERSION --no-git-tag-version
+
+      - name: Generate changelog
+        if: steps.version.outputs.new_tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          custom_release_rules: |
+            *:patch:Patch Release
+            feat:minor:Minor Release
+            fix:patch:Patch Release
+            docs:patch:Documentation
+            style:patch:Code Style
+            refactor:patch:Code Refactoring
+            perf:patch:Performance Improvements
+            test:patch:Tests
+            build:patch:Build System
+            ci:patch:Continuous Integration
+            chore:patch:Chores
+            revert:patch:Reverts
+
+      - name: Publish to npm
+        if: steps.version.outputs.new_tag
+        run: pnpm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.new_tag
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.new_tag }}
+          name: Release ${{ steps.version.outputs.new_version }}
+          body: ${{ steps.version.outputs.changelog }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,9 @@
     "offchain",
     "UNFCCC",
     "usdc",
-    "NFTIPFSSchema"
+    "NFTIPFSSchema",
+    "mathieudutour",
+    "softprops"
   ],
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"


### PR DESCRIPTION
## Summary

This PR adds a new GitHub Actions workflow for automated package publishing to npm. The workflow includes:

- Automated version bumping based on conventional commits
- Type checking and linting
- Package building
- npm publication
- GitHub release creation