### PR TITLE
Optimize pnpm and Node.js setup in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,15 +19,17 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
       - name: Setup pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
         with:
           version: '10.14.0'
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '22.15.0'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Type check


### PR DESCRIPTION
## Summary

This PR optimizes the pnpm and Node.js setup in the GitHub Actions publish workflow by reordering setup steps and adding caching configuration.

## Changes

- Reordered setup steps: pnpm setup now occurs before Node.js setup
- Added `run_install: false` to pnpm setup configuration
- Updated Node.js version from '22' to '22.15.0' for more precise versioning
- Added pnpm cache configuration to the Node.js setup for improved performance

## Benefits

- Better dependency management workflow
- Improved caching for faster CI runs
- More precise Node.js version specification
- Cleaner setup sequence

## Testing

The changes have been tested locally and the workflow should function as expected with the optimized setup.
