### PR TITLE
feat: add comprehensive signature definition to shared schema

### DIFF
--- a/schemas/ipfs/shared/definitions/definitions.schema.json
+++ b/schemas/ipfs/shared/definitions/definitions.schema.json
@@ -244,6 +244,70 @@
       "title": "Relationship Type",
       "description": "Type of relationship between records.",
       "example": "mass-id"
+    },
+    "signature": {
+      "type": "object",
+      "title": "Cryptographic Signature",
+      "description": "Cryptographic signature for data integrity verification.",
+      "required": ["signer", "signing_method", "domain", "hash_algorithm", "hash", "signature"],
+      "properties": {
+        "signer": {
+          "$ref": "#/$defs/ethereum_address",
+          "title": "Signer Address",
+          "description": "Ethereum address that signed the data."
+        },
+        "signing_method": {
+          "type": "string",
+          "title": "Signing Method",
+          "description": "Method used to sign the data.",
+          "example": "eip712-offchain"
+        },
+        "domain": {
+          "type": "object",
+          "title": "EIP-712 Domain",
+          "description": "EIP-712 domain separator information.",
+          "required": ["name", "version", "chain_id"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Domain Name",
+              "description": "Name of the signing domain.",
+              "example": "Carrot GasID"
+            },
+            "version": {
+              "type": "string",
+              "title": "Domain Version",
+              "description": "Version of the signing domain.",
+              "example": "1.0.0"
+            },
+            "chain_id": {
+              "$ref": "#/$defs/chain_id",
+              "title": "Chain ID",
+              "description": "Blockchain chain ID for the domain."
+            }
+          },
+          "additionalProperties": false
+        },
+        "hash_algorithm": {
+          "type": "string",
+          "title": "Hash Algorithm",
+          "description": "Algorithm used to hash the data.",
+          "example": "keccak256"
+        },
+        "hash": {
+          "$ref": "#/$defs/keccak256_hash",
+          "title": "Data Hash",
+          "description": "Hash of the signed data."
+        },
+        "signature": {
+          "type": "string",
+          "pattern": "^0x[a-fA-F0-9]{130}$",
+          "title": "Signature",
+          "description": "65-byte ECDSA signature as hex string (r + s + v).",
+          "example": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1c"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary
- Add EIP-712 cryptographic signature structure to shared definitions
- Include signer address, signing method, domain separator, hash algorithm
- Add ECDSA signature validation

## Changes
Add comprehensive signature definition in `schemas/ipfs/shared/definitions/definitions.schema.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)