### PR TITLE
refactor: change creator.id format from URI to UUID

### DIFF
--- a/schemas/ipfs/shared/base/base.schema.json
+++ b/schemas/ipfs/shared/base/base.schema.json
@@ -88,9 +88,8 @@
           "description": "Company or individual name that created this record."
         },
         "id": {
-          "type": "string",
-          "format": "uri",
-          "description": "Unique identifier for the creator, such as a website or DID."
+          "$ref": "../definitions/definitions.schema.json#/$defs/uuid",
+          "description": "Unique identifier for the creator."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary
- Change creator.id field in base schema from URI format to UUID format
- Reference shared definitions for UUID validation
- Align with standardized UUID-based identification

## Changes
Update `schemas/ipfs/shared/base/base.schema.json` to use UUID format for creator.id

🤖 Generated with [Claude Code](https://claude.com/claude-code)