### PR TITLE
Add Origin Country Subdivision cross-validation to all schemas

### DIFF
--- a/src/gas-id/__tests__/gas-id.schema.spec.ts
+++ b/src/gas-id/__tests__/gas-id.schema.spec.ts
@@ -212,4 +212,19 @@ describe('GasIDIpfsSchema', () => {
       'Recycling Date attribute must equal data.summary.recycling_date as a Unix timestamp in milliseconds',
     ]);
   });
+
+  it('requires Origin Country Subdivision attribute to match origin location', () => {
+    expectIssuesContain(schema, () => {
+      const next = structuredClone(base);
+      const subdivisionIndex = next.attributes.findIndex(
+        (attr) => attr.trait_type === 'Origin Country Subdivision',
+      );
+      if (subdivisionIndex >= 0) {
+        next.attributes[subdivisionIndex].value = 'BR-RJ';
+      }
+      return next;
+    }, [
+      'Origin Country Subdivision attribute must equal data.origin_location.subdivision_code',
+    ]);
+  });
 });

--- a/src/gas-id/gas-id.schema.ts
+++ b/src/gas-id/gas-id.schema.ts
@@ -168,6 +168,17 @@ export const GasIDIpfsSchema = NftIpfsSchema.safeExtend({
     validateAttributeValue({
       ctx,
       attributeByTraitType,
+      traitType: 'Origin Country Subdivision',
+      expectedValue: data.origin_location.subdivision_code,
+      missingMessage:
+        'Origin Country Subdivision attribute must be present and match data.origin_location.subdivision_code',
+      mismatchMessage:
+        'Origin Country Subdivision attribute must equal data.origin_location.subdivision_code',
+    });
+
+    validateAttributeValue({
+      ctx,
+      attributeByTraitType,
       traitType: 'MassID',
       expectedValue: `#${data.mass_id.token_id}`,
       missingMessage:

--- a/src/mass-id/__tests__/mass-id.schema.spec.ts
+++ b/src/mass-id/__tests__/mass-id.schema.spec.ts
@@ -81,6 +81,33 @@ describe('MassIDIpfsSchema', () => {
     }, ['Waste Subtype attribute must equal waste_properties.subtype']);
   });
 
+  it('requires Origin Country Subdivision attribute to match pick-up location', () => {
+    expectIssuesContain(schema, () => {
+      const next = structuredClone(base);
+      const subdivisionIndex = next.attributes.findIndex(
+        (attr) => attr.trait_type === 'Origin Country Subdivision',
+      );
+      if (subdivisionIndex >= 0) {
+        next.attributes[subdivisionIndex].value = 'BR-RJ';
+      }
+      return next;
+    }, [
+      'Origin Country Subdivision attribute must equal Pick-up event location.subdivision_code',
+    ]);
+  });
+
+  it('requires Origin Country Subdivision attribute to be omitted when pick-up event is absent', () => {
+    expectIssuesContain(schema, () => {
+      const next = structuredClone(base);
+      next.data.events = next.data.events.filter(
+        (event) => event.event_name !== 'Pick-up',
+      );
+      return next;
+    }, [
+      'Origin Country Subdivision attribute must be omitted when Pick-up event location.subdivision_code is not provided',
+    ]);
+  });
+
   it('requires pick-up date attribute to match pick-up event', () => {
     expectIssuesContain(schema, () => {
       const next = structuredClone(base);

--- a/src/mass-id/mass-id.schema.ts
+++ b/src/mass-id/mass-id.schema.ts
@@ -154,6 +154,17 @@ export const MassIDIpfsSchema = NftIpfsSchema.safeExtend({
         'Origin City attribute must equal Pick-up event location.city',
     });
 
+    validateAttributeValue({
+      ctx,
+      attributeByTraitType,
+      traitType: 'Origin Country Subdivision',
+      expectedValue: pickUpLocation?.subdivision_code,
+      missingMessage:
+        'Origin Country Subdivision attribute must be omitted when Pick-up event location.subdivision_code is not provided',
+      mismatchMessage:
+        'Origin Country Subdivision attribute must equal Pick-up event location.subdivision_code',
+    });
+
     validateDateTimeAttribute({
       ctx,
       attributeByTraitType,

--- a/src/recycled-id/__tests__/recycled-id.schema.spec.ts
+++ b/src/recycled-id/__tests__/recycled-id.schema.spec.ts
@@ -191,4 +191,19 @@ describe('RecycledIDIpfsSchema', () => {
       'Recycling Date attribute must equal data.summary.recycling_date as a Unix timestamp in milliseconds',
     ]);
   });
+
+  it('requires Origin Country Subdivision attribute to match origin location', () => {
+    expectIssuesContain(schema, () => {
+      const next = structuredClone(base);
+      const subdivisionIndex = next.attributes.findIndex(
+        (attr) => attr.trait_type === 'Origin Country Subdivision',
+      );
+      if (subdivisionIndex >= 0) {
+        next.attributes[subdivisionIndex].value = 'BR-RJ';
+      }
+      return next;
+    }, [
+      'Origin Country Subdivision attribute must equal data.origin_location.subdivision_code',
+    ]);
+  });
 });

--- a/src/recycled-id/recycled-id.schema.ts
+++ b/src/recycled-id/recycled-id.schema.ts
@@ -158,6 +158,17 @@ export const RecycledIDIpfsSchema = NftIpfsSchema.safeExtend({
     validateAttributeValue({
       ctx,
       attributeByTraitType,
+      traitType: 'Origin Country Subdivision',
+      expectedValue: data.origin_location.subdivision_code,
+      missingMessage:
+        'Origin Country Subdivision attribute must be present and match data.origin_location.subdivision_code',
+      mismatchMessage:
+        'Origin Country Subdivision attribute must equal data.origin_location.subdivision_code',
+    });
+
+    validateAttributeValue({
+      ctx,
+      attributeByTraitType,
       traitType: 'MassID',
       expectedValue: `#${data.mass_id.token_id}`,
       missingMessage:


### PR DESCRIPTION
### 🧾 Summary

Add missing `Origin Country Subdivision` attribute cross-validation to **all three schema types** (MassID, GasID, RecycledID), ensuring the NFT attribute value matches the underlying location data.

### 🧩 Context

**Why this change?** `Origin Country Subdivision` is a required NFT attribute in all three schemas but had no `superRefine` validation linking it to the underlying data.

**Problem it solves:** A token with a location in `BR-SP` (São Paulo) but an `Origin Country Subdivision` attribute set to `BR-RJ` (Rio de Janeiro) would pass schema validation silently — in MassID, GasID, and RecycledID.

**Business value:** Ensures data integrity of all tokenized NFTs by preventing subdivision mismatches between attributes and location data.

### 🧱 Scope of this PR

**This PR includes:**

- [x] Bug fixes

**Schemas fixed:**

| Schema | Validates against |
|---|---|
| MassID | `pickUpLocation?.subdivision_code` (from Pick-up event location) |
| GasID | `data.origin_location.subdivision_code` |
| RecycledID | `data.origin_location.subdivision_code` |

### 🧪 How to test

```bash
pnpm check          # All quality gates
pnpm test:coverage  # 100% coverage maintained
```

New test cases per schema:
- **MassID**: mismatch test + omission test (when Pick-up event absent)
- **GasID**: mismatch test
- **RecycledID**: mismatch test

### 🧠 Considerations for Review

**Focus areas for review:**

- [x] Business logic correctness
- [x] Test coverage

**Key files to review:**

- `src/mass-id/mass-id.schema.ts` — validates against pick-up event location
- `src/gas-id/gas-id.schema.ts` — validates against `data.origin_location`
- `src/recycled-id/recycled-id.schema.ts` — validates against `data.origin_location`
- Test files for all three schemas

---

### ✅ Pre-merge Checklist

#### Code Quality

- [x] Code follows project style guidelines and naming conventions
- [x] All new code has appropriate test coverage
- [x] Linter warnings and errors have been resolved
- [x] No debugging code or console logs remain

#### Review & Testing

- [x] Self-review completed with focus on edge cases
- [x] Manual testing performed in appropriate environment
- [x] Breaking changes clearly identified and justified
- [x] All tests pass locally

#### Final Confirmation

- [x] **I confirm this PR works as expected, follows best practices, and improves codebase quality**