### PR TITLE
Reject zero weight in WeightKgSchema

### DIFF
--- a/schemas/ipfs/gas-id/gas-id.example.json
+++ b/schemas/ipfs/gas-id/gas-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.4.0/schemas/ipfs/gas-id/gas-id.schema.json",
   "schema": {
-    "hash": "246a79dde06ffa758bed2192815e95db55616aef09712712349523243af92522",
+    "hash": "73e1251670c0345dd57c8ab9d9b1ff7cd62d56e247d4f7b02e205eff5a812828",
     "type": "GasID",
     "version": "0.4.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2024-12-08T11:32:47.000Z",
   "external_id": "d2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6",
   "external_url": "https://explore.carrot.eco/document/d2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6",
-  "audit_data_hash": "a29c3e1d572e53c462c8629c8d4a238accff7f392ba0d586f7de81c766b9252d",
+  "audit_data_hash": "208971647ea2259206ef9f56d0d3620dc66d95dd11287d40fc35e2f89a1f317b",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/gas-id/gas-id.schema.json
+++ b/schemas/ipfs/gas-id/gas-id.schema.json
@@ -205,7 +205,7 @@
             },
             "prevented_co2e_kg": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Prevented Emissions (CO₂e)",
               "description": "CO₂e weight of the prevented emissions in kilograms (kg)",
               "examples": [
@@ -499,7 +499,7 @@
             },
             "weight_kg": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Source Waste Net Weight",
               "description": "Net weight of the source waste in kilograms (kg)",
               "examples": [
@@ -1219,7 +1219,7 @@
             },
             "value": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Source Weight",
               "description": "Weight of the source waste in kilograms",
               "examples": [

--- a/schemas/ipfs/mass-id/mass-id.example.json
+++ b/schemas/ipfs/mass-id/mass-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.4.0/schemas/ipfs/mass-id/mass-id.schema.json",
   "schema": {
-    "hash": "5ab20ba833d5da3893f8c936aadb955799aab1478b18c343e3dbb16b8d832338",
+    "hash": "268ac4f38deb922fdf610c460f704c9aee2302d3a1543876df12f7528c58ba10",
     "type": "MassID",
     "version": "0.4.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -108,7 +108,7 @@
       "display_type": "date"
     }
   ],
-  "audit_data_hash": "aa00b6d675627e8429bdbea04032923a15fa10d71b6a63318c8bb8a6c94c020a",
+  "audit_data_hash": "9fb0ed743394fb51c1afbe1bb0563f5ccda34786178b75099e20610f01427f76",
   "data": {
     "waste_properties": {
       "type": "Organic",

--- a/schemas/ipfs/mass-id/mass-id.schema.json
+++ b/schemas/ipfs/mass-id/mass-id.schema.json
@@ -231,7 +231,7 @@
             },
             "weight_kg": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Net Weight",
               "description": "Net weight of the waste batch in kilograms (kg)",
               "examples": [
@@ -497,7 +497,7 @@
                         "title": "Pick-up Waste Weight",
                         "description": "Weight of waste collected at the origin location, measured in kilograms (kg)",
                         "type": "number",
-                        "minimum": 0,
+                        "exclusiveMinimum": 0,
                         "examples": [
                           500.35,
                           3000
@@ -652,7 +652,7 @@
                         "title": "Container Capacity",
                         "description": "Maximum container capacity in kilograms (kg)",
                         "type": "number",
-                        "minimum": 0,
+                        "exclusiveMinimum": 0,
                         "examples": [
                           500.35,
                           3000
@@ -662,7 +662,7 @@
                         "title": "Gross Weight",
                         "description": "Total weight including vehicle/container before tare in kilograms (kg)",
                         "type": "number",
-                        "minimum": 0,
+                        "exclusiveMinimum": 0,
                         "examples": [
                           500.35,
                           3000
@@ -672,7 +672,7 @@
                         "title": "Tare Weight",
                         "description": "Weight of the empty vehicle or container in kilograms (kg)",
                         "type": "number",
-                        "minimum": 0,
+                        "exclusiveMinimum": 0,
                         "examples": [
                           500.35,
                           3000
@@ -812,7 +812,7 @@
                         "title": "Initial Weight",
                         "description": "Weight of the material entering the sorting process in kilograms (kg)",
                         "type": "number",
-                        "minimum": 0,
+                        "exclusiveMinimum": 0,
                         "examples": [
                           500.35,
                           3000
@@ -822,7 +822,7 @@
                         "title": "Deducted Weight",
                         "description": "Weight removed during sorting (e.g., contaminants or moisture) in kilograms (kg)",
                         "type": "number",
-                        "minimum": 0,
+                        "exclusiveMinimum": 0,
                         "examples": [
                           500.35,
                           3000
@@ -1289,7 +1289,7 @@
               },
               "value": {
                 "type": "number",
-                "minimum": 0,
+                "exclusiveMinimum": 0,
                 "title": "Weight",
                 "description": "Net batch weight in kilograms (kg) for this MassID",
                 "examples": [

--- a/schemas/ipfs/recycled-id/recycled-id.example.json
+++ b/schemas/ipfs/recycled-id/recycled-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.4.0/schemas/ipfs/recycled-id/recycled-id.schema.json",
   "schema": {
-    "hash": "2b2af0e13b5291f0950e6e19c40dc3cc9eb1e4581a468fb4ee434aeb888dbe91",
+    "hash": "46c1f327b982cff17e045c0a8ef46545695f0e45c7d9a5477fcb62c2a309886c",
     "type": "RecycledID",
     "version": "0.4.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2024-12-08T11:32:47.000Z",
   "external_id": "f47ac10b-58cc-4372-a567-0e02b2c3d489",
   "external_url": "https://explore.carrot.eco/document/f47ac10b-58cc-4372-a567-0e02b2c3d489",
-  "audit_data_hash": "de8c8f2aef8daa5cd4ee67c4750af17082f6889d0965067947942a6efc1237d0",
+  "audit_data_hash": "5e1cfd996925d72067f363f051d573a2ae805e10d6b3c1ea5bd65d5cb890abf5",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/recycled-id/recycled-id.schema.json
+++ b/schemas/ipfs/recycled-id/recycled-id.schema.json
@@ -170,7 +170,7 @@
           "properties": {
             "recycled_mass_kg": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Recycled Weight",
               "description": "Total weight of materials successfully recycled in kilograms (kg)",
               "examples": [
@@ -487,7 +487,7 @@
             },
             "weight_kg": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Source Waste Net Weight",
               "description": "Net weight of the source waste in kilograms (kg)",
               "examples": [
@@ -871,7 +871,7 @@
             },
             "value": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Recycled Weight",
               "description": "Total weight of recycled materials in kilograms",
               "examples": [
@@ -1056,7 +1056,7 @@
             },
             "value": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Source Weight",
               "description": "Weight of the source waste in kilograms",
               "examples": [

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -2,7 +2,7 @@
   "version": "0.4.0",
   "schemas": {
     "ipfs/recycled-id/recycled-id.schema.json": {
-      "hash": "2b2af0e13b5291f0950e6e19c40dc3cc9eb1e4581a468fb4ee434aeb888dbe91",
+      "hash": "46c1f327b982cff17e045c0a8ef46545695f0e45c7d9a5477fcb62c2a309886c",
       "path": "ipfs/recycled-id/recycled-id.schema.json"
     },
     "ipfs/methodology/methodology.schema.json": {
@@ -14,11 +14,11 @@
       "path": "ipfs/mass-id-audit/mass-id-audit.schema.json"
     },
     "ipfs/mass-id/mass-id.schema.json": {
-      "hash": "5ab20ba833d5da3893f8c936aadb955799aab1478b18c343e3dbb16b8d832338",
+      "hash": "268ac4f38deb922fdf610c460f704c9aee2302d3a1543876df12f7528c58ba10",
       "path": "ipfs/mass-id/mass-id.schema.json"
     },
     "ipfs/gas-id/gas-id.schema.json": {
-      "hash": "246a79dde06ffa758bed2192815e95db55616aef09712712349523243af92522",
+      "hash": "73e1251670c0345dd57c8ab9d9b1ff7cd62d56e247d4f7b02e205eff5a812828",
       "path": "ipfs/gas-id/gas-id.schema.json"
     },
     "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json": {

--- a/src/shared/schemas/primitives/__tests__/numbers.schema.spec.ts
+++ b/src/shared/schemas/primitives/__tests__/numbers.schema.spec.ts
@@ -5,6 +5,7 @@ import {
   NonNegativeIntegerSchema,
   PercentageSchema,
   UsdcAmountSchema,
+  WeightKgSchema,
 } from '../numbers.schema';
 
 describe('NonNegativeFloatSchema', () => {
@@ -15,6 +16,22 @@ describe('NonNegativeFloatSchema', () => {
 
   it('rejects negative values', () => {
     expectSchemaInvalid(NonNegativeFloatSchema, 1, () => -1);
+  });
+});
+
+describe('WeightKgSchema', () => {
+  it('validates positive weights', () => {
+    expectSchemaValid(WeightKgSchema, () => 0.1);
+    expectSchemaValid(WeightKgSchema, () => 500.35);
+    expectSchemaValid(WeightKgSchema, () => 3000);
+  });
+
+  it('rejects zero weight', () => {
+    expectSchemaInvalid(WeightKgSchema, 1, () => 0);
+  });
+
+  it('rejects negative weight', () => {
+    expectSchemaInvalid(WeightKgSchema, 1, () => -5);
   });
 });
 

--- a/src/shared/schemas/primitives/__tests__/numbers.schema.spec.ts
+++ b/src/shared/schemas/primitives/__tests__/numbers.schema.spec.ts
@@ -4,6 +4,7 @@ import {
   NonNegativeFloatSchema,
   NonNegativeIntegerSchema,
   PercentageSchema,
+  PositiveFloatSchema,
   UsdcAmountSchema,
   WeightKgSchema,
 } from '../numbers.schema';
@@ -16,6 +17,21 @@ describe('NonNegativeFloatSchema', () => {
 
   it('rejects negative values', () => {
     expectSchemaInvalid(NonNegativeFloatSchema, 1, () => -1);
+  });
+});
+
+describe('PositiveFloatSchema', () => {
+  it('validates values greater than zero', () => {
+    expectSchemaValid(PositiveFloatSchema, () => 0.1);
+    expectSchemaValid(PositiveFloatSchema, () => 72.5);
+  });
+
+  it('rejects zero', () => {
+    expectSchemaInvalid(PositiveFloatSchema, 1, () => 0);
+  });
+
+  it('rejects negative values', () => {
+    expectSchemaInvalid(PositiveFloatSchema, 1, () => -1);
   });
 });
 

--- a/src/shared/schemas/primitives/numbers.schema.ts
+++ b/src/shared/schemas/primitives/numbers.schema.ts
@@ -10,15 +10,22 @@ export const NonNegativeFloatSchema = z
   });
 export type NonNegativeFloat = z.infer<typeof NonNegativeFloatSchema>;
 
-export const WeightKgSchema = z
+export const PositiveFloatSchema = z
   .number()
   .gt(0)
   .meta({
-    title: 'Weight',
-    description:
-      'Weight measurement in kilograms (kg), must be greater than zero',
-    examples: [500.35, 3000],
+    title: 'Positive Float',
+    description: 'Floating-point number greater than zero',
+    examples: [0.1, 45.2, 72.5],
   });
+export type PositiveFloat = z.infer<typeof PositiveFloatSchema>;
+
+export const WeightKgSchema = PositiveFloatSchema.meta({
+  title: 'Weight',
+  description:
+    'Weight measurement in kilograms (kg), must be greater than zero',
+  examples: [500.35, 3000],
+});
 export type WeightKg = z.infer<typeof WeightKgSchema>;
 
 export const PercentageSchema = NonNegativeFloatSchema.max(100).meta({

--- a/src/shared/schemas/primitives/numbers.schema.ts
+++ b/src/shared/schemas/primitives/numbers.schema.ts
@@ -10,11 +10,15 @@ export const NonNegativeFloatSchema = z
   });
 export type NonNegativeFloat = z.infer<typeof NonNegativeFloatSchema>;
 
-export const WeightKgSchema = NonNegativeFloatSchema.meta({
-  title: 'Weight',
-  description: 'Weight measurement in kilograms (kg)',
-  examples: [500.35, 3000],
-});
+export const WeightKgSchema = z
+  .number()
+  .gt(0)
+  .meta({
+    title: 'Weight',
+    description:
+      'Weight measurement in kilograms (kg), must be greater than zero',
+    examples: [500.35, 3000],
+  });
 export type WeightKg = z.infer<typeof WeightKgSchema>;
 
 export const PercentageSchema = NonNegativeFloatSchema.max(100).meta({


### PR DESCRIPTION
### 🧾 Summary

Change `WeightKgSchema` to reject zero values — a 0 kg waste batch is semantically invalid. Uses `z.number().gt(0)` instead of inheriting `.min(0)` from `NonNegativeFloatSchema`.

### 🧩 Context

**Why this change?** `WeightKgSchema` previously extended `NonNegativeFloatSchema` which uses `.min(0)`, allowing zero-weight waste batches to pass validation.

**Problem it solves:** A MassID with `weight_kg: 0` would pass schema validation despite being physically impossible — you can't tokenize a waste batch with no weight.

**Business value:** Prevents invalid zero-weight waste batches from being tokenized into NFTs.

### 🧱 Scope of this PR

**This PR includes:**

- [x] Bug fixes

**Intentionally excluded:**

- `NonNegativeFloatSchema` is unchanged — other consumers (`PercentageSchema`, `CreditAmountSchema`, `UsdcAmountSchema`) still allow 0

### 🧪 How to test

```bash
pnpm test
```

3 new test cases for `WeightKgSchema`:
1. Validates positive weights (0.1, 500.35, 3000)
2. Rejects zero weight
3. Rejects negative weight

### 🧠 Considerations for Review

**Focus areas for review:**

- [x] Business logic correctness

**Key files to review:**

- `src/shared/schemas/primitives/numbers.schema.ts` — `WeightKgSchema` now uses `z.number().gt(0)` directly instead of extending `NonNegativeFloatSchema`
- `src/shared/schemas/primitives/__tests__/numbers.schema.spec.ts` — 3 new test cases

### 🚨 Breaking Changes & Migration

This is a stricter validation — any data with `weight_kg: 0` that previously passed will now be rejected. This is intentional; zero-weight waste batches should not exist.

---

### ✅ Pre-merge Checklist

#### Code Quality

- [x] Code follows project style guidelines and naming conventions
- [x] All new code has appropriate test coverage
- [x] Linter warnings and errors have been resolved
- [x] No debugging code or console logs remain

#### Review & Testing

- [x] Self-review completed with focus on edge cases
- [x] Manual testing performed in appropriate environment
- [x] Breaking changes clearly identified and justified
- [x] All tests pass locally

#### Final Confirmation

- [x] **I confirm this PR works as expected, follows best practices, and improves codebase quality**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking validation change: any existing records with `0` for weight/emissions fields that previously passed schema validation will now be rejected. Risk is moderate because it touches shared primitives and multiple IPFS JSON schemas but is narrowly scoped to numeric constraints.
> 
> **Overview**
> Makes kilogram-based fields strictly positive by introducing `PositiveFloatSchema` and updating `WeightKgSchema` to reject `0`, with new unit tests covering the behavior.
> 
> Updates the IPFS JSON schemas for `MassID`, `GasID`, and `RecycledID` to use `exclusiveMinimum: 0` (instead of `minimum: 0`) for weight/emissions fields, and refreshes example/schema hash artifacts (`*.example.json` hashes, `audit_data_hash`, and `schemas/schema-hashes.json`) accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 923c93be0f33c74de8bb83d1ad95e3068c9b2228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->