### PR TITLE
Relax receipt identity optionality across buyer, beneficiary, and credit holder

### DIFF
--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.4.2/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "bf4f35ef32d26e399d9da04c321ef6247c5cddcbd29d1a3ef7e9a42df2a65431",
+    "hash": "11aec87953c68fb05c071bf295f3c89a1db56ff6b7453a67c022cff3dfecef6e",
     "type": "CreditPurchaseReceipt",
     "version": "0.4.2",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "e90b1a7d25d8e83b4fac241370762dd0a5217ded7e1f213f0a4e72cb2db48abb",
+  "audit_data_hash": "1ca5db25c7c1ac512ab34ff55a5cd446a911a319aa1642be81209d1deace1b1f",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -250,45 +250,40 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 100,
                   "title": "Identity Name",
                   "description": "Display name of the buyer or beneficiary on the receipt",
                   "examples": [
                     "EcoTech Solutions Inc.",
                     "Climate Action Corp"
-                  ]
+                  ],
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 100
                 },
                 "external_id": {
+                  "title": "Identity External ID",
+                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
                   "type": "string",
                   "format": "uuid",
                   "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
-                  "title": "Identity External ID",
-                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
                   "examples": [
                     "ad44dd3f-f176-4b98-bf78-5ee6e77d0530"
                   ]
                 },
                 "external_url": {
-                  "type": "string",
-                  "format": "uri",
                   "title": "Identity External URL",
                   "description": "Link to the buyer or beneficiary profile page on the Carrot platform",
+                  "type": "string",
+                  "format": "uri",
                   "examples": [
                     "https://explore.carrot.eco/",
                     "https://whitepaper.carrot.eco/"
                   ]
                 }
               },
-              "required": [
-                "name",
-                "external_id",
-                "external_url"
-              ],
               "additionalProperties": false,
               "title": "Identity",
-              "description": "Identity information for the buyer or beneficiary associated with this receipt"
+              "description": "Identity information for the buyer or beneficiary associated with this receipt. All fields are optional, but at least one must be provided when the identity block is present."
             }
           },
           "required": [

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.4.2/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "schema": {
-    "hash": "d59a322cc951bd8ee4fe5189a02c7e0c06a9ac7db93135b13905c35448fbe32b",
+    "hash": "1875e909deaac770cc888743d8442f724fee59c6af55df3c8cfd5fd51ab23778",
     "type": "CreditRetirementReceipt",
     "version": "0.4.2",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -230,5 +230,5 @@
       "smart_contract_address": "0x742d35cc6634c0532925a3b8d8b5c2d4c7f8e1a9"
     }
   },
-  "audit_data_hash": "285b8bebd9c7a5b6a1dd03cedb9e7f0a3033d8dcb7e6d61cc4f94ba4a1075e1d"
+  "audit_data_hash": "6564ee55007f7415884497f9429c1ccc13dcade20aefd0253057586da2dc8501"
 }

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
@@ -228,50 +228,44 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 100,
                   "title": "Identity Name",
                   "description": "Display name of the buyer or beneficiary on the receipt",
                   "examples": [
                     "EcoTech Solutions Inc.",
                     "Climate Action Corp"
-                  ]
+                  ],
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 100
                 },
                 "external_id": {
+                  "title": "Identity External ID",
+                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
                   "type": "string",
                   "format": "uuid",
                   "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
-                  "title": "Identity External ID",
-                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
                   "examples": [
                     "ad44dd3f-f176-4b98-bf78-5ee6e77d0530"
                   ]
                 },
                 "external_url": {
-                  "type": "string",
-                  "format": "uri",
                   "title": "Identity External URL",
                   "description": "Link to the buyer or beneficiary profile page on the Carrot platform",
+                  "type": "string",
+                  "format": "uri",
                   "examples": [
                     "https://explore.carrot.eco/",
                     "https://whitepaper.carrot.eco/"
                   ]
                 }
               },
-              "required": [
-                "name",
-                "external_id",
-                "external_url"
-              ],
               "additionalProperties": false,
               "title": "Identity",
-              "description": "Identity information for the buyer or beneficiary associated with this receipt"
+              "description": "Identity information for the buyer or beneficiary associated with this receipt. All fields are optional, but at least one must be provided when the identity block is present."
             }
           },
           "required": [
-            "beneficiary_id",
-            "identity"
+            "beneficiary_id"
           ],
           "additionalProperties": false,
           "title": "Beneficiary",
@@ -293,45 +287,40 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 100,
                   "title": "Identity Name",
                   "description": "Display name of the buyer or beneficiary on the receipt",
                   "examples": [
                     "EcoTech Solutions Inc.",
                     "Climate Action Corp"
-                  ]
+                  ],
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 100
                 },
                 "external_id": {
+                  "title": "Identity External ID",
+                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
                   "type": "string",
                   "format": "uuid",
                   "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
-                  "title": "Identity External ID",
-                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
                   "examples": [
                     "ad44dd3f-f176-4b98-bf78-5ee6e77d0530"
                   ]
                 },
                 "external_url": {
-                  "type": "string",
-                  "format": "uri",
                   "title": "Identity External URL",
                   "description": "Link to the buyer or beneficiary profile page on the Carrot platform",
+                  "type": "string",
+                  "format": "uri",
                   "examples": [
                     "https://explore.carrot.eco/",
                     "https://whitepaper.carrot.eco/"
                   ]
                 }
               },
-              "required": [
-                "name",
-                "external_id",
-                "external_url"
-              ],
               "additionalProperties": false,
               "title": "Identity",
-              "description": "Identity information for the buyer or beneficiary associated with this receipt"
+              "description": "Identity information for the buyer or beneficiary associated with this receipt. All fields are optional, but at least one must be provided when the identity block is present."
             }
           },
           "required": [
@@ -1067,7 +1056,7 @@
       }
     },
     "attributes": {
-      "minItems": 4,
+      "minItems": 3,
       "type": "array",
       "items": {
         "anyOf": [
@@ -1113,54 +1102,6 @@
             "additionalProperties": false,
             "title": "Total Credits Retired Attribute",
             "description": "Total number of credits retired across all tokens attribute with numeric display"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "trait_type": {
-                "type": "string",
-                "const": "Beneficiary"
-              },
-              "value": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 100,
-                "title": "Beneficiary",
-                "description": "Beneficiary receiving the retirement benefit",
-                "examples": [
-                  "Climate Action Corp"
-                ]
-              },
-              "display_type": {
-                "title": "Display Type",
-                "description": "How the trait should be displayed in marketplace UIs",
-                "type": "string",
-                "enum": [
-                  "number",
-                  "date",
-                  "boost_number",
-                  "boost_percentage"
-                ]
-              },
-              "max_value": {
-                "title": "Max Value",
-                "description": "Maximum possible value for numeric traits",
-                "type": "number",
-                "minimum": 0,
-                "examples": [
-                  0,
-                  45.2,
-                  72.5
-                ]
-              }
-            },
-            "required": [
-              "trait_type",
-              "value"
-            ],
-            "additionalProperties": false,
-            "title": "Beneficiary Attribute",
-            "description": "Attribute containing the beneficiary display name"
           },
           {
             "type": "object",
@@ -1236,6 +1177,54 @@
             "additionalProperties": false,
             "title": "Certificates Retired Attribute",
             "description": "Total number of certificates retired attribute with numeric display"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "trait_type": {
+                "type": "string",
+                "const": "Beneficiary"
+              },
+              "value": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100,
+                "title": "Beneficiary",
+                "description": "Beneficiary receiving the retirement benefit",
+                "examples": [
+                  "Climate Action Corp"
+                ]
+              },
+              "display_type": {
+                "title": "Display Type",
+                "description": "How the trait should be displayed in marketplace UIs",
+                "type": "string",
+                "enum": [
+                  "number",
+                  "date",
+                  "boost_number",
+                  "boost_percentage"
+                ]
+              },
+              "max_value": {
+                "title": "Max Value",
+                "description": "Maximum possible value for numeric traits",
+                "type": "number",
+                "minimum": 0,
+                "examples": [
+                  0,
+                  45.2,
+                  72.5
+                ]
+              }
+            },
+            "required": [
+              "trait_type",
+              "value"
+            ],
+            "additionalProperties": false,
+            "title": "Beneficiary Attribute",
+            "description": "Attribute containing the beneficiary display name"
           },
           {
             "type": "object",
@@ -1421,7 +1410,7 @@
         ]
       },
       "title": "Credit Retirement Receipt NFT Attribute Array",
-      "description": "Attributes for credit retirement receipts including per-credit breakdowns, totals, beneficiary, credit holder, retirement date, certificate count, and optional purchase info. Fixed required attributes: Total Credits Retired, Beneficiary, Retirement Date, Certificates Retired. Conditional attributes: Credit Holder (required when credit_holder.identity.name is provided), Purchase Date (optional, when purchase_receipt is present), Purchase Receipt (optional, when purchase_receipt is present). Dynamic attributes: Credit attributes (one per credit symbol in data.credits).\n\nRequired attributes (4): Total Credits Retired, Beneficiary, Retirement Date, Certificates Retired"
+      "description": "Attributes for credit retirement receipts including per-credit breakdowns, totals, beneficiary, credit holder, retirement date, certificate count, and optional purchase info. Fixed required attributes: Total Credits Retired, Retirement Date, Certificates Retired. Conditional attributes: Beneficiary (required when beneficiary.identity.name is provided), Credit Holder (required when credit_holder.identity.name is provided), Purchase Date (optional, when purchase_receipt is present), Purchase Receipt (optional, when purchase_receipt is present). Dynamic attributes: Credit attributes (one per credit symbol in data.credits).\n\nRequired attributes (3): Total Credits Retired, Retirement Date, Certificates Retired"
     }
   },
   "required": [
@@ -1443,7 +1432,7 @@
   ],
   "additionalProperties": false,
   "title": "CreditRetirementReceipt NFT IPFS Record",
-  "description": "Complete CreditRetirementReceipt NFT IPFS record including retirement summary, beneficiary and credit holder details, credit breakdowns, certificate allocations, and NFT display attributes",
+  "description": "Complete CreditRetirementReceipt NFT IPFS record including retirement summary, beneficiary and credit holder details (identity optional), credit breakdowns, certificate allocations, and NFT display attributes",
   "$id": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.4.2/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "version": "0.4.2"
 }

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -22,11 +22,11 @@
       "path": "ipfs/gas-id/gas-id.schema.json"
     },
     "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json": {
-      "hash": "d59a322cc951bd8ee4fe5189a02c7e0c06a9ac7db93135b13905c35448fbe32b",
+      "hash": "1875e909deaac770cc888743d8442f724fee59c6af55df3c8cfd5fd51ab23778",
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "bf4f35ef32d26e399d9da04c321ef6247c5cddcbd29d1a3ef7e9a42df2a65431",
+      "hash": "11aec87953c68fb05c071bf295f3c89a1db56ff6b7453a67c022cff3dfecef6e",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
@@ -112,6 +112,17 @@ describe('CreditPurchaseReceiptDataSchema', () => {
     });
   });
 
+  it('allows buyer identity with only external_url', () => {
+    expectSchemaValid(schema, () => {
+      const valid = structuredClone(baseData);
+      valid.buyer.identity = {
+        external_url: 'https://example.com/identity/eco-tech',
+      };
+
+      return valid;
+    });
+  });
+
   it('rejects certificate collection retired_amount greater than purchased_amount', () => {
     expectSchemaInvalid(schema, baseData, (invalid) => {
       invalid.certificates[0].collections[0].retired_amount =

--- a/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.schema.spec.ts
+++ b/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.schema.spec.ts
@@ -41,6 +41,37 @@ describe('CreditRetirementReceiptIpfsSchema', () => {
     });
   });
 
+  it('allows beneficiary identity to be omitted', () => {
+    expectSchemaValid(schema, () => {
+      const withoutBeneficiaryIdentity = structuredClone(base);
+      Reflect.deleteProperty(
+        withoutBeneficiaryIdentity.data.beneficiary as Record<string, unknown>,
+        'identity',
+      );
+      withoutBeneficiaryIdentity.attributes =
+        withoutBeneficiaryIdentity.attributes.filter(
+          (attribute) => attribute.trait_type !== 'Beneficiary',
+        );
+
+      return withoutBeneficiaryIdentity;
+    });
+  });
+
+  it('allows beneficiary identity with only external_id', () => {
+    expectSchemaValid(schema, () => {
+      const withPartialBeneficiaryIdentity = structuredClone(base);
+      withPartialBeneficiaryIdentity.data.beneficiary.identity = {
+        external_id: 'ad44dd3f-f176-4b98-bf78-5ee6e77d0530',
+      };
+      withPartialBeneficiaryIdentity.attributes =
+        withPartialBeneficiaryIdentity.attributes.filter(
+          (attribute) => attribute.trait_type !== 'Beneficiary',
+        );
+
+      return withPartialBeneficiaryIdentity;
+    });
+  });
+
   runReceiptInvalidCases(schema, base, [
     {
       description: 'rejects invalid schema type',
@@ -94,6 +125,18 @@ describe('CreditRetirementReceiptIpfsSchema', () => {
         invalid.attributes = invalid.attributes.filter(
           (attribute) => attribute.trait_type !== 'Beneficiary',
         );
+      },
+    },
+    {
+      description:
+        'rejects beneficiary attribute value that does not match identity name',
+      mutate: (invalid) => {
+        invalid.attributes = invalid.attributes.map((attribute) => {
+          if (attribute.trait_type === 'Beneficiary') {
+            return { ...attribute, value: 'Totally-Different-Name' };
+          }
+          return attribute;
+        });
       },
     },
     {

--- a/src/credit-retirement-receipt/credit-retirement-receipt.attributes.ts
+++ b/src/credit-retirement-receipt/credit-retirement-receipt.attributes.ts
@@ -98,12 +98,12 @@ const CreditRetirementReceiptPurchaseReceiptAttributeSchema =
 
 const REQUIRED_CREDIT_RETIREMENT_RECEIPT_ATTRIBUTES = [
   CreditRetirementReceiptTotalCreditsAttributeSchema,
-  CreditRetirementReceiptBeneficiaryAttributeSchema,
   CreditRetirementReceiptRetirementDateAttributeSchema,
   CreditRetirementReceiptCertificatesAttributeSchema,
 ] as const;
 
 const CONDITIONAL_CREDIT_RETIREMENT_RECEIPT_ATTRIBUTES = [
+  CreditRetirementReceiptBeneficiaryAttributeSchema,
   CreditRetirementReceiptCreditHolderAttributeSchema,
   CreditRetirementReceiptPurchaseDateAttributeSchema,
   CreditRetirementReceiptPurchaseReceiptAttributeSchema,
@@ -123,14 +123,13 @@ export const CreditRetirementReceiptAttributesSchema =
     title: 'Credit Retirement Receipt NFT Attribute Array',
     description:
       'Attributes for credit retirement receipts including per-credit breakdowns, totals, beneficiary, credit holder, retirement date, certificate count, and optional purchase info. ' +
-      'Fixed required attributes: Total Credits Retired, Beneficiary, Retirement Date, Certificates Retired. ' +
-      'Conditional attributes: Credit Holder (required when credit_holder.identity.name is provided), Purchase Date (optional, when purchase_receipt is present), Purchase Receipt (optional, when purchase_receipt is present). ' +
+      'Fixed required attributes: Total Credits Retired, Retirement Date, Certificates Retired. ' +
+      'Conditional attributes: Beneficiary (required when beneficiary.identity.name is provided), Credit Holder (required when credit_holder.identity.name is provided), Purchase Date (optional, when purchase_receipt is present), Purchase Receipt (optional, when purchase_receipt is present). ' +
       'Dynamic attributes: Credit attributes (one per credit symbol in data.credits).',
     uniqueBySelector: (attribute: unknown) =>
       (attribute as { trait_type: string }).trait_type,
     requiredTraitTypes: [
       'Total Credits Retired',
-      'Beneficiary',
       'Retirement Date',
       'Certificates Retired',
     ],

--- a/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
+++ b/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
@@ -35,7 +35,7 @@ const CreditRetirementReceiptBeneficiarySchema = z
       description:
         'UUID identifying the beneficiary of the retirement (bytes16 normalized to UUID)',
     }),
-    identity: CreditRetirementReceiptIdentitySchema,
+    identity: CreditRetirementReceiptIdentitySchema.optional(),
   })
   .meta({
     title: 'Beneficiary',

--- a/src/credit-retirement-receipt/credit-retirement-receipt.schema.ts
+++ b/src/credit-retirement-receipt/credit-retirement-receipt.schema.ts
@@ -18,7 +18,7 @@ import { CreditRetirementReceiptAttributesSchema } from './credit-retirement-rec
 export const CreditRetirementReceiptIpfsSchemaMeta = {
   title: 'CreditRetirementReceipt NFT IPFS Record',
   description:
-    'Complete CreditRetirementReceipt NFT IPFS record including retirement summary, beneficiary and credit holder details, credit breakdowns, certificate allocations, and NFT display attributes',
+    'Complete CreditRetirementReceipt NFT IPFS record including retirement summary, beneficiary and credit holder details (identity optional), credit breakdowns, certificate allocations, and NFT display attributes',
   $id: buildSchemaUrl(
     'credit-retirement-receipt/credit-retirement-receipt.schema.json',
   ),
@@ -101,15 +101,19 @@ export const CreditRetirementReceiptIpfsSchema = NftIpfsSchema.safeExtend({
         'Attribute "Certificates Retired" must match data.summary.total_certificates',
     });
 
-    validateAttributeValue({
-      ctx,
-      attributeByTraitType,
-      traitType: 'Beneficiary',
-      expectedValue: String(data.beneficiary.identity.name),
-      missingMessage: 'Attribute "Beneficiary" is required',
-      mismatchMessage:
-        'Attribute "Beneficiary" must match beneficiary.identity.name',
-    });
+    const beneficiaryName = data.beneficiary.identity?.name;
+    if (beneficiaryName) {
+      validateAttributeValue({
+        ctx,
+        attributeByTraitType,
+        traitType: 'Beneficiary',
+        expectedValue: String(beneficiaryName),
+        missingMessage:
+          'Attribute "Beneficiary" is required when beneficiary.identity.name is provided',
+        mismatchMessage:
+          'Attribute "Beneficiary" must match beneficiary.identity.name',
+      });
+    }
 
     const creditHolderName = data.credit_holder.identity?.name;
     if (creditHolderName) {

--- a/src/shared/schemas/receipt/__tests__/receipt-identity.spec.ts
+++ b/src/shared/schemas/receipt/__tests__/receipt-identity.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { ReceiptIdentitySchema } from '../receipt.schemas';
+
+describe('ReceiptIdentitySchema', () => {
+  const validName = 'EcoTech Solutions Inc.';
+  const validExternalId = 'ad44dd3f-f176-4b98-bf78-5ee6e77d0530';
+  const validExternalUrl = 'https://example.com/identity/eco-tech';
+
+  it.each([
+    [
+      'all three fields set',
+      {
+        name: validName,
+        external_id: validExternalId,
+        external_url: validExternalUrl,
+      },
+    ],
+    ['only name', { name: validName }],
+    ['only external_id', { external_id: validExternalId }],
+    ['only external_url', { external_url: validExternalUrl }],
+    ['name + external_id', { name: validName, external_id: validExternalId }],
+    [
+      'external_id + external_url',
+      { external_id: validExternalId, external_url: validExternalUrl },
+    ],
+  ])('accepts identity with %s', (_label, input) => {
+    const result = ReceiptIdentitySchema.safeParse(input);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty identity object', () => {
+    const result = ReceiptIdentitySchema.safeParse({});
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toContain(
+      'at least one of: name, external_id, external_url',
+    );
+  });
+
+  it('rejects empty string name', () => {
+    const result = ReceiptIdentitySchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-uuid external_id', () => {
+    const result = ReceiptIdentitySchema.safeParse({
+      external_id: 'not-a-uuid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects malformed external_url', () => {
+    const result = ReceiptIdentitySchema.safeParse({
+      external_url: 'not-a-url',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown fields (strict)', () => {
+    const result = ReceiptIdentitySchema.safeParse({
+      name: validName,
+      unknown_field: 'x',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/shared/schemas/receipt/receipt.schemas.ts
+++ b/src/shared/schemas/receipt/receipt.schemas.ts
@@ -70,26 +70,38 @@ export type CreditRetirementReceiptSummary = z.infer<
 
 export const ReceiptIdentitySchema = z
   .strictObject({
-    name: NonEmptyStringSchema.max(100).meta({
-      title: 'Identity Name',
-      description: 'Display name of the buyer or beneficiary on the receipt',
-      examples: ['EcoTech Solutions Inc.', 'Climate Action Corp'],
-    }),
-    external_id: ExternalIdSchema.meta({
+    name: NonEmptyStringSchema.max(100)
+      .optional()
+      .meta({
+        title: 'Identity Name',
+        description: 'Display name of the buyer or beneficiary on the receipt',
+        examples: ['EcoTech Solutions Inc.', 'Climate Action Corp'],
+      }),
+    external_id: ExternalIdSchema.optional().meta({
       title: 'Identity External ID',
       description:
         'Unique identifier for the buyer or beneficiary in the Carrot platform',
     }),
-    external_url: ExternalUrlSchema.meta({
+    external_url: ExternalUrlSchema.optional().meta({
       title: 'Identity External URL',
       description:
         'Link to the buyer or beneficiary profile page on the Carrot platform',
     }),
   })
+  .refine(
+    (value) =>
+      value.name !== undefined ||
+      value.external_id !== undefined ||
+      value.external_url !== undefined,
+    {
+      message:
+        'identity must include at least one of: name, external_id, external_url',
+    },
+  )
   .meta({
     title: 'Identity',
     description:
-      'Identity information for the buyer or beneficiary associated with this receipt',
+      'Identity information for the buyer or beneficiary associated with this receipt. All fields are optional, but at least one must be provided when the identity block is present.',
   });
 export type ReceiptIdentity = z.infer<typeof ReceiptIdentitySchema>;
 


### PR DESCRIPTION
### 🧾 Summary

Relax `ReceiptIdentitySchema` so each subfield is independently optional, make `beneficiary.identity` optional, and flip the `"Beneficiary"` NFT attribute rule to conditional parity with the existing `"Credit Holder"` rule. Unblocks smaug's CRT-376 beneficiary/credit-holder plumbing.

### 🧩 Context

**Why this change?** smaug's `CreditOrderEntity` only carries a single `buyer` identity today. CRT-376 adds optional `beneficiary` and `creditHolder` fields so retirement receipts can distinguish the three personas. The current receipt schemas over-specify identity, which would force smaug to fabricate UUIDs and URLs to satisfy constraints that don't match its data reality.

**Problem it solves:** over-specified identity block rejects legitimate receipts that are missing a `name`, `external_id`, or `external_url` — fields smaug genuinely doesn't have yet for beneficiary / credit holder entities.

**Business value:** smaug can ship CRT-376 without fabricating data; schema shape matches the data the platform actually produces.

### 🧱 Scope of this PR

**This PR includes:**

- [x] Bug fixes — over-specified identity contract
- [x] Refactoring — flip `Beneficiary` attribute rule from unconditional to conditional, symmetric to the existing `Credit Holder` rule

**Intentionally excluded** _(to be addressed in future PRs):_

- smaug-side beneficiary / credit-holder entity plumbing (CRT-376, consumes the new `0.5.0` release)

### 🚨 Breaking Changes & Migration

No behavior-breaking change for existing consumers. Previously-valid payloads still validate; only newly-permitted shapes are now accepted (subfield-optional, identity-optional on beneficiary). The one guard added is an explicit rejection of empty `{}` identity blocks via `.refine()`, which were implicitly valid before but carried zero information.

No retirement receipts have been minted on mainnet, so the `beneficiary.identity` relaxation is safe.

### 🧪 How to test

```bash
pnpm check
pnpm test:coverage
```

All green locally: 640 tests pass, 100% branch/function/line/statement coverage.

Manual schema-level sanity:

- `ReceiptIdentitySchema.safeParse({})` → fails with "must include at least one of: name, external_id, external_url"
- `ReceiptIdentitySchema.safeParse({ name: 'X' })` → succeeds
- `CreditRetirementReceiptIpfsSchema` with `beneficiary.identity` omitted and `Beneficiary` attribute removed → validates
- Same schema with `beneficiary.identity.name` set but the `Beneficiary` attribute missing → fails as expected

### 📦 Deployment Notes

- Minor version bump (0.4.2 → 0.5.0) on release — change is purely permissive relative to previously-valid inputs.
- smaug imports `CreditPurchaseReceiptJsonSchema` + pre-computed hashes directly from `schemas/schema-hashes.json`; both are regenerated here and move in lockstep with `pnpm update @carrot-foundation/schemas`.

### 🧠 Considerations for Review

**Focus areas for review:**

- [x] Business logic correctness
- [x] Test coverage
- [x] API design

**Key files to review:**

- `src/shared/schemas/receipt/receipt.schemas.ts` — `ReceiptIdentitySchema` relaxation + `.refine()` for at-least-one-field guard
- `src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts` — `beneficiary.identity` flipped to optional
- `src/credit-retirement-receipt/credit-retirement-receipt.schema.ts` — conditional `Beneficiary` attribute rule + IPFS meta description
- `src/credit-retirement-receipt/credit-retirement-receipt.attributes.ts` — `Beneficiary` moved from REQUIRED to CONDITIONAL array (forced consequence: `createOrderedAttributesSchema` would otherwise double-enforce the attribute unconditionally, contradicting the new rule)
- `src/shared/schemas/receipt/__tests__/receipt-identity.spec.ts` — 11 new cases on the relaxed shared schema
- `src/credit-retirement-receipt/__tests__/credit-retirement-receipt.schema.spec.ts` — new beneficiary-optional and mismatched-attribute cases
- `src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts` — buyer sanity test for cascaded shared-schema relaxation

### 🔗 Related Links

- ClickUp: [CRT-377](https://app.clickup.com/t/86agzwt87)
- Blocks: [CRT-376](https://app.clickup.com/t/86agzwgt3)

---

### ✅ Pre-merge Checklist

#### Code Quality

- [x] Code follows project style guidelines and naming conventions
- [x] All new code has appropriate test coverage (100% maintained)
- [x] Linter warnings and errors have been resolved
- [x] No debugging code or console logs remain

#### Review & Testing

- [x] Self-review completed with focus on edge cases
- [x] Manual testing performed via `pnpm test:coverage`
- [x] Breaking changes clearly identified and justified (none)
- [x] All tests pass locally

#### Final Confirmation

- [x] **I confirm this PR works as expected, follows best practices, and improves codebase quality**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation rules for receipt identities and retirement NFT attributes, which can affect downstream consumers that assume fields/attributes are always present. Risk is moderated by being mostly permissive and covered by new tests, but schema hash updates may require coordinated dependency bumps.
> 
> **Overview**
> Relaxes `ReceiptIdentitySchema` so `name`, `external_id`, and `external_url` are independently optional while **rejecting empty `{}` identities** via a new “at least one field” refinement.
> 
> Updates credit retirement receipts to allow omitting `data.beneficiary.identity`, and makes the `Beneficiary` NFT attribute **conditional** (only required/validated when `beneficiary.identity.name` is present), aligning it with the existing `Credit Holder` behavior; this also lowers required retirement `attributes` `minItems` from 4→3.
> 
> Regenerates JSON schemas/examples and `schemas/schema-hashes.json`, and adds/updates tests to cover partial identities, omitted beneficiary identity, and attribute/value mismatch cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151c92fe1c13f9468139291bff140b7714bbbf0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->