### PR TITLE
fix(schema): refine IPFS field descriptions across mass-id and credit receipt schemas

### DIFF
--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.0/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "40ba58979807543bbe19044a36ea875287529c55339ddacf2c3de23ba088b9b9",
+    "hash": "d13eb5c79ebe829b5147dcf018b575c79904199a4fd5fc571d1dcbbeb9a0d8c5",
     "type": "CreditPurchaseReceipt",
     "version": "0.5.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "9c7807027eb9b9b31d559d9cef3bddb7e16d54761c0552c794d9aa021f9d24d5",
+  "audit_data_hash": "c5ffd1b26af6947f3d257556b6c87b3d7ed1dd53ed0593129df5f8c7ddc501a9",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.0/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "d13eb5c79ebe829b5147dcf018b575c79904199a4fd5fc571d1dcbbeb9a0d8c5",
+    "hash": "e165e49ac0a7c570aa3531ff3cdefa5a68aecae06b2f31790d77fa4cef8ed886",
     "type": "CreditPurchaseReceipt",
     "version": "0.5.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "c5ffd1b26af6947f3d257556b6c87b3d7ed1dd53ed0593129df5f8c7ddc501a9",
+  "audit_data_hash": "1cde4d437bc01cb1730e3cefa1bf61b1721781c2abf041055629288473b26ce0",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -1168,7 +1168,7 @@
                 "exclusiveMinimum": 0,
                 "maximum": 9007199254740991,
                 "title": "Retirement Date",
-                "description": "Present in the attributes array only when the purchase has been retired (when data.retirement_receipt is set)",
+                "description": "Unix timestamp in milliseconds when credits were retired; present in the attributes array only when the purchase has been retired (data.retirement_receipt is set)",
                 "examples": [
                   1704067200000
                 ]
@@ -1185,7 +1185,7 @@
             ],
             "additionalProperties": false,
             "title": "Retirement Date Attribute",
-            "description": "Present in the attributes array only when the purchase has been retired (when data.retirement_receipt is set) attribute using Unix timestamp in milliseconds"
+            "description": "Unix timestamp in milliseconds when credits were retired; present in the attributes array only when the purchase has been retired (data.retirement_receipt is set) attribute"
           },
           {
             "type": "object",

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -262,7 +262,7 @@
                 },
                 "external_id": {
                   "title": "Identity External ID",
-                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
+                  "description": "Unique identifier of the associated entity in the Carrot platform",
                   "type": "string",
                   "format": "uuid",
                   "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
@@ -921,7 +921,7 @@
     },
     "external_links": {
       "title": "External Links",
-      "description": "Optional list of public resource links with labels",
+      "description": "Supplementary reference links (label, URL, optional description) displayed on the NFT page",
       "type": "array",
       "items": {
         "type": "object",
@@ -1168,7 +1168,7 @@
                 "exclusiveMinimum": 0,
                 "maximum": 9007199254740991,
                 "title": "Retirement Date",
-                "description": "Unix timestamp in milliseconds when credits were retired (if retirement occurred)",
+                "description": "Present in the attributes array only when the purchase has been retired (when data.retirement_receipt is set)",
                 "examples": [
                   1704067200000
                 ]
@@ -1185,7 +1185,7 @@
             ],
             "additionalProperties": false,
             "title": "Retirement Date Attribute",
-            "description": "Unix timestamp in milliseconds when credits were retired (if retirement occurred) attribute"
+            "description": "Present in the attributes array only when the purchase has been retired (when data.retirement_receipt is set) attribute using Unix timestamp in milliseconds"
           },
           {
             "type": "object",

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.0/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "schema": {
-    "hash": "a9f8b2b1fe20a8fe40a5c38b33dc832f0701f827ffd086761a10264b50b2b651",
+    "hash": "4c4e23bfd6f458ce4f94c7d93efb0a16714ff4af2f21608e49b09315352de54b",
     "type": "CreditRetirementReceipt",
     "version": "0.5.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -230,5 +230,5 @@
       "smart_contract_address": "0x742d35cc6634c0532925a3b8d8b5c2d4c7f8e1a9"
     }
   },
-  "audit_data_hash": "3d8eb879d16a70ff98221375f848236c5286a63551a5350568bc47dab9197f4a"
+  "audit_data_hash": "aef86131f82dade4020f4240373689b7f662d0c2b84d356979049de2a28e7c36"
 }

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
@@ -219,7 +219,7 @@
               "format": "uuid",
               "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
               "title": "Retirement Beneficiary ID",
-              "description": "UUID identifying the beneficiary of the retirement (bytes16 normalized to UUID)",
+              "description": "UUID identifying the beneficiary of the retirement within the Carrot platform",
               "examples": [
                 "ad44dd3f-f176-4b98-bf78-5ee6e77d0530"
               ]
@@ -240,7 +240,7 @@
                 },
                 "external_id": {
                   "title": "Identity External ID",
-                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
+                  "description": "Unique identifier of the associated entity in the Carrot platform",
                   "type": "string",
                   "format": "uuid",
                   "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
@@ -278,7 +278,7 @@
               "type": "string",
               "pattern": "^0x[a-f0-9]{40}$",
               "title": "Credit Holder Wallet Address",
-              "description": "Ethereum address of the credit holder surrendering credits",
+              "description": "Ethereum address of the wallet that held and surrendered the credits",
               "examples": [
                 "0x1234567890abcdef1234567890abcdef12345678"
               ]
@@ -299,7 +299,7 @@
                 },
                 "external_id": {
                   "title": "Identity External ID",
-                  "description": "Unique identifier for the buyer or beneficiary in the Carrot platform",
+                  "description": "Unique identifier of the associated entity in the Carrot platform",
                   "type": "string",
                   "format": "uuid",
                   "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
@@ -1012,7 +1012,7 @@
     },
     "external_links": {
       "title": "External Links",
-      "description": "Optional list of public resource links with labels",
+      "description": "Supplementary reference links (label, URL, optional description) displayed on the NFT page",
       "type": "array",
       "items": {
         "type": "object",

--- a/schemas/ipfs/gas-id/gas-id.example.json
+++ b/schemas/ipfs/gas-id/gas-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.0/schemas/ipfs/gas-id/gas-id.schema.json",
   "schema": {
-    "hash": "6d22b905bc69f3436c60776c1aef0fff1712e920e7a9e0702f35ddb0ddb563cf",
+    "hash": "559acdede2bdd34aef73321c4e4ce2bd559790f8ae80210e995d4a43a712c0c2",
     "type": "GasID",
     "version": "0.5.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2024-12-08T11:32:47.000Z",
   "external_id": "d2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6",
   "external_url": "https://explore.carrot.eco/document/d2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6",
-  "audit_data_hash": "451fc3960552c2d911ceb465f2aff4a94ea8410849b25f7a24ce279d5ab1287d",
+  "audit_data_hash": "a7dd574d982d6bfe6eb46d084318ac34d0d50406a35491416561ba29b2a34f1a",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/gas-id/gas-id.schema.json
+++ b/schemas/ipfs/gas-id/gas-id.schema.json
@@ -878,7 +878,7 @@
     },
     "external_links": {
       "title": "External Links",
-      "description": "Optional list of public resource links with labels",
+      "description": "Supplementary reference links (label, URL, optional description) displayed on the NFT page",
       "type": "array",
       "items": {
         "type": "object",

--- a/schemas/ipfs/mass-id/mass-id.example.json
+++ b/schemas/ipfs/mass-id/mass-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.0/schemas/ipfs/mass-id/mass-id.schema.json",
   "schema": {
-    "hash": "15675848245673646f2b4c81f31843a45ccfc395b33abcaa636ac28821ba6ab4",
+    "hash": "39cfb22c9a1aef46a8157b019934cf717e847b711f8d089f0f4db04ce9976ede",
     "type": "MassID",
     "version": "0.5.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -108,7 +108,7 @@
       "display_type": "date"
     }
   ],
-  "audit_data_hash": "32bac4ba104ae74a83eae0df972254b12907fdb875df3be5d94490d9d563d100",
+  "audit_data_hash": "50fc8cb9b3b51069b35116b9d8eefdcdd99825a752e54d1fb215fc8f00cb5168",
   "data": {
     "waste_properties": {
       "type": "Organic",

--- a/schemas/ipfs/mass-id/mass-id.schema.json
+++ b/schemas/ipfs/mass-id/mass-id.schema.json
@@ -233,7 +233,7 @@
               "type": "number",
               "exclusiveMinimum": 0,
               "title": "Net Weight",
-              "description": "Net weight of the waste batch in kilograms (kg)",
+              "description": "Weight in kilograms of the entire waste batch tracked through the chain of custody",
               "examples": [
                 3000
               ]
@@ -452,7 +452,7 @@
                     "type": "string",
                     "pattern": "^[0-9a-fA-F]{64}$",
                     "title": "Location ID Hash",
-                    "description": "Reference to location in the locations array",
+                    "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
                       "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
                     ]
@@ -552,7 +552,7 @@
                     "type": "string",
                     "pattern": "^[0-9a-fA-F]{64}$",
                     "title": "Location ID Hash",
-                    "description": "Reference to location in the locations array",
+                    "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
                       "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
                     ]
@@ -727,7 +727,7 @@
                     "type": "string",
                     "pattern": "^[0-9a-fA-F]{64}$",
                     "title": "Location ID Hash",
-                    "description": "Reference to location in the locations array",
+                    "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
                       "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
                     ]
@@ -789,7 +789,7 @@
                     "type": "string",
                     "pattern": "^[0-9a-fA-F]{64}$",
                     "title": "Location ID Hash",
-                    "description": "Reference to location in the locations array",
+                    "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
                       "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
                     ]
@@ -877,7 +877,7 @@
                     "type": "string",
                     "pattern": "^[0-9a-fA-F]{64}$",
                     "title": "Location ID Hash",
-                    "description": "Reference to location in the locations array",
+                    "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
                       "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
                     ]
@@ -1126,7 +1126,7 @@
     },
     "external_links": {
       "title": "External Links",
-      "description": "Optional list of public resource links with labels",
+      "description": "Supplementary reference links (label, URL, optional description) displayed on the NFT page",
       "type": "array",
       "items": {
         "type": "object",

--- a/schemas/ipfs/recycled-id/recycled-id.example.json
+++ b/schemas/ipfs/recycled-id/recycled-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.0/schemas/ipfs/recycled-id/recycled-id.schema.json",
   "schema": {
-    "hash": "015d4867c1d7acc28ccf8f678b75d95f679918a650ff55c52597cfcd21fa1f4f",
+    "hash": "0b9c6f260f326bdd0b31761c5aa689bdb540dbb811e1870b37e65fae1191ba09",
     "type": "RecycledID",
     "version": "0.5.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2024-12-08T11:32:47.000Z",
   "external_id": "f47ac10b-58cc-4372-a567-0e02b2c3d489",
   "external_url": "https://explore.carrot.eco/document/f47ac10b-58cc-4372-a567-0e02b2c3d489",
-  "audit_data_hash": "8c4fa1d6333dd59e613ba04238b24eceb63bba7b952bbe4af43adadc33721dbc",
+  "audit_data_hash": "6e3c739689d75d1cac0fbda477669dad3da5ac1e9d9a42d900217880d05e0fc9",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/recycled-id/recycled-id.schema.json
+++ b/schemas/ipfs/recycled-id/recycled-id.schema.json
@@ -765,7 +765,7 @@
     },
     "external_links": {
       "title": "External Links",
-      "description": "Optional list of public resource links with labels",
+      "description": "Supplementary reference links (label, URL, optional description) displayed on the NFT page",
       "type": "array",
       "items": {
         "type": "object",

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -2,7 +2,7 @@
   "version": "0.5.0",
   "schemas": {
     "ipfs/recycled-id/recycled-id.schema.json": {
-      "hash": "015d4867c1d7acc28ccf8f678b75d95f679918a650ff55c52597cfcd21fa1f4f",
+      "hash": "0b9c6f260f326bdd0b31761c5aa689bdb540dbb811e1870b37e65fae1191ba09",
       "path": "ipfs/recycled-id/recycled-id.schema.json"
     },
     "ipfs/methodology/methodology.schema.json": {
@@ -14,19 +14,19 @@
       "path": "ipfs/mass-id-audit/mass-id-audit.schema.json"
     },
     "ipfs/mass-id/mass-id.schema.json": {
-      "hash": "15675848245673646f2b4c81f31843a45ccfc395b33abcaa636ac28821ba6ab4",
+      "hash": "39cfb22c9a1aef46a8157b019934cf717e847b711f8d089f0f4db04ce9976ede",
       "path": "ipfs/mass-id/mass-id.schema.json"
     },
     "ipfs/gas-id/gas-id.schema.json": {
-      "hash": "6d22b905bc69f3436c60776c1aef0fff1712e920e7a9e0702f35ddb0ddb563cf",
+      "hash": "559acdede2bdd34aef73321c4e4ce2bd559790f8ae80210e995d4a43a712c0c2",
       "path": "ipfs/gas-id/gas-id.schema.json"
     },
     "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json": {
-      "hash": "a9f8b2b1fe20a8fe40a5c38b33dc832f0701f827ffd086761a10264b50b2b651",
+      "hash": "4c4e23bfd6f458ce4f94c7d93efb0a16714ff4af2f21608e49b09315352de54b",
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "40ba58979807543bbe19044a36ea875287529c55339ddacf2c3de23ba088b9b9",
+      "hash": "d13eb5c79ebe829b5147dcf018b575c79904199a4fd5fc571d1dcbbeb9a0d8c5",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -26,7 +26,7 @@
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "d13eb5c79ebe829b5147dcf018b575c79904199a4fd5fc571d1dcbbeb9a0d8c5",
+      "hash": "e165e49ac0a7c570aa3531ff3cdefa5a68aecae06b2f31790d77fa4cef8ed886",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {

--- a/src/credit-purchase-receipt/credit-purchase-receipt.attributes.ts
+++ b/src/credit-purchase-receipt/credit-purchase-receipt.attributes.ts
@@ -79,7 +79,7 @@ const CreditPurchaseReceiptRetirementDateAttributeSchema =
     traitType: 'Retirement Date',
     title: 'Retirement Date',
     description:
-      'Unix timestamp in milliseconds when credits were retired (if retirement occurred)',
+      'Unix timestamp in milliseconds when credits were retired; present in the attributes array only when the purchase has been retired (data.retirement_receipt is set)',
   });
 
 const CreditPurchaseReceiptRetirementReceiptAttributeSchema =

--- a/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
+++ b/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
@@ -33,7 +33,7 @@ const CreditRetirementReceiptBeneficiarySchema = z
     beneficiary_id: ExternalIdSchema.meta({
       title: 'Retirement Beneficiary ID',
       description:
-        'UUID identifying the beneficiary of the retirement (bytes16 normalized to UUID)',
+        'UUID identifying the beneficiary of the retirement within the Carrot platform',
     }),
     identity: CreditRetirementReceiptIdentitySchema.optional(),
   })
@@ -49,7 +49,8 @@ const CreditRetirementReceiptCreditHolderSchema = z
   .strictObject({
     wallet_address: EthereumAddressSchema.meta({
       title: 'Credit Holder Wallet Address',
-      description: 'Ethereum address of the credit holder surrendering credits',
+      description:
+        'Ethereum address of the wallet that held and surrendered the credits',
     }),
     identity: CreditRetirementReceiptIdentitySchema.optional(),
   })

--- a/src/mass-id/mass-id.data.schema.ts
+++ b/src/mass-id/mass-id.data.schema.ts
@@ -48,7 +48,8 @@ const MassIDWastePropertiesSchema = z
     local_classification: MassIDLocalClassificationSchema.optional(),
     weight_kg: WeightKgSchema.meta({
       title: 'Net Weight',
-      description: 'Net weight of the waste batch in kilograms (kg)',
+      description:
+        'Weight in kilograms of the entire waste batch tracked through the chain of custody',
       examples: [3000],
     }),
   })
@@ -111,7 +112,8 @@ const MassIDBaseEventSchema = z
     participant_id_hash: ParticipantIdHashSchema,
     location_id_hash: Sha256HashSchema.meta({
       title: 'Location ID Hash',
-      description: 'Reference to location in the locations array',
+      description:
+        'Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`',
     }),
   })
   .meta({

--- a/src/shared/schemas/core/nft.schema.ts
+++ b/src/shared/schemas/core/nft.schema.ts
@@ -195,7 +195,8 @@ export const NftIpfsSchema = BaseIpfsSchema.safeExtend({
     .optional()
     .meta({
       title: 'External Links',
-      description: 'Optional list of public resource links with labels',
+      description:
+        'Supplementary reference links (label, URL, optional description) displayed on the NFT page',
     }),
   attributes: uniqueBy(
     NftAttributeSchema,

--- a/src/shared/schemas/receipt/receipt.schemas.ts
+++ b/src/shared/schemas/receipt/receipt.schemas.ts
@@ -80,7 +80,7 @@ export const ReceiptIdentitySchema = z
     external_id: ExternalIdSchema.optional().meta({
       title: 'Identity External ID',
       description:
-        'Unique identifier for the buyer or beneficiary in the Carrot platform',
+        'Unique identifier of the associated entity in the Carrot platform',
     }),
     external_url: ExternalUrlSchema.optional().meta({
       title: 'Identity External URL',


### PR DESCRIPTION
### 🧾 Summary

Refines 7 `.meta()` descriptions across MassID and credit receipt IPFS schemas for clarity, accuracy, and role-neutrality. Description-only — no shape or validation changes.

### 🧩 Context

**Why this change?** Audit (CRT-381) identified schema field descriptions that were ambiguous, stale, or leaked implementation details into the public JSON Schema output consumed by `@carrot-foundation/schemas` package consumers.

**Problem it solves:** Consumers (smaug, docs, tooltips, validation error messages) see clearer, role-neutral, and more accurate field descriptions.

**Business value:** Reduces onboarding friction and classification ambiguity when integrating with the schemas package; removes implementation details (e.g., "bytes16 normalized to UUID") that don't belong in public docs.

### 🧱 Scope of this PR

**This PR includes:**

- [x] Documentation updates (schema field `.meta()` descriptions)

**Intentionally excluded** _(to be addressed in future PRs):_

- Shared primitive description edits (e.g., `ExternalIdSchema`) — scoped to composition-site overrides only
- `CertificateReferenceBaseSchema` description refinements — no active smaug consumer; deferred to a tighter follow-up PR when a consumer exists
- MassID audit, Gas ID, Recycled ID schemas — not in the CRT-381 audit scope

### 🧪 How to test

Locally:

```bash
pnpm lint
pnpm type-check
pnpm test                # 640 tests, 100% coverage enforced
pnpm update-examples
pnpm hash-schemas
pnpm validate-schemas    # 18/18 passed
pnpm validate-examples   # 9/9 passed
pnpm check               # full gate: size-limit, publint, attw, ai:check
```

All pipelines pass locally on this branch.

### 🧠 Considerations for Review

**Focus areas for review:**

- [x] Description accuracy against current schema behavior
- [x] Role-neutrality of shared field descriptions (`ReceiptIdentitySchema.external_id`)
- [x] No shape/validation regressions (generated JSON Schemas only differ in `description` strings, plus the resulting schema-hash updates)

**Key files to review:**

- `src/shared/schemas/receipt/receipt.schemas.ts` — role-neutral `ReceiptIdentitySchema.external_id` (now shared across buyer/beneficiary/credit_holder)
- `src/mass-id/mass-id.data.schema.ts` — `WastePropertiesSchema.weight_kg` + `MassIDBaseEvent.location_id_hash`
- `src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts` — `beneficiary_id` (drops "bytes16 normalized") + `credit_holder.wallet_address` (tense consistency)
- `src/shared/schemas/core/nft.schema.ts` — `NftIpfsSchema.external_links` (explicit shape)
- `src/credit-purchase-receipt/credit-purchase-receipt.attributes.ts` — "Retirement Date" attribute description preserves Unix-ms format and clarifies conditional presence

Generated artifact diffs (`schemas/ipfs/**/*.schema.json`, `*.example.json`, `schema-hashes.json`) are a direct consequence of the description edits and should be reviewed as mechanically-generated output.

### 🔗 Related Links

- ClickUp: CRT-381 — IPFS receipt schema field descriptions audit

---

### ✅ Pre-merge Checklist

#### Code Quality

- [x] Code follows project style guidelines and naming conventions
- [x] All new code has appropriate test coverage — N/A, description-only; existing 640 tests still pass at 100% coverage
- [x] Linter warnings and errors have been resolved
- [x] No debugging code or console logs remain

#### Review & Testing

- [x] Self-review completed with focus on edge cases
- [x] Manual testing performed in appropriate environment — full local pipeline including `pnpm check`
- [x] Breaking changes clearly identified and justified — none
- [x] All tests pass locally

#### Final Confirmation

- [x] **I confirm this PR works as expected, follows best practices, and improves codebase quality**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to schema/metadata `description` strings and regenerated schema/example hash artifacts, with no validation or data-shape modifications.
> 
> **Overview**
> Updates several IPFS JSON Schema field descriptions to be clearer and more role-neutral across credit purchase/retirement receipts and MassID (e.g., `ReceiptIdentity.external_id`, `external_links`, MassID `weight_kg` and `location_id_hash`, and purchase receipt `Retirement Date` attribute conditionality).
> 
> Regenerates the derived `schemas/ipfs/**/*.schema.json` and `*.example.json` artifacts and bumps corresponding entries in `schemas/schema-hashes.json`/embedded `schema.hash` and `audit_data_hash` values to match the updated schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06403f96b79320694a285094ddb1f17315eb6bb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->