### PR TITLE
feat(schema): hash participant ids + uniform identity blocks on credit receipts (CRT-382)

### DIFF
--- a/schemas/ipfs/collection/collection.example.json
+++ b/schemas/ipfs/collection/collection.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/collection/collection.schema.json",
   "schema": {
-    "hash": "ac9ab55eb672748c69c3421259fffa7e6257f080d2e722859085b245cf226f91",
+    "hash": "fefd645f1167494243989ecebe6db02b5f9d338373fe741a53902ab785dc39ee",
     "type": "Collection",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"

--- a/schemas/ipfs/collection/collection.schema.json
+++ b/schemas/ipfs/collection/collection.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "2343c61b35d66f24a5bc6f2bb7d070415a5f8b4d8b54b870b4e5d496e69fa75b",
+    "hash": "6d61ee689ef2a5ab52b9727f60288905ba3e7a282c27080d342229e3344e0521",
     "type": "CreditPurchaseReceipt",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "f8cdebe74ce0f98105d552188ff17a98cacf2645e38786549512d41d0ebc5d1e",
+  "audit_data_hash": "4990bf613bd8c6742f46d4607209ee9a11d651bd7df0629d7f2c40a45eb1780c",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "bc9882d5b3da7f685798b9e9c7757fddcf1cbe7f9fd6584c176d10b96a722219",
+    "hash": "2343c61b35d66f24a5bc6f2bb7d070415a5f8b4d8b54b870b4e5d496e69fa75b",
     "type": "CreditPurchaseReceipt",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "de79f6ec3ef1aaab4d20d3153bb014dfd8b85a54f070f762ec2e571024978359",
+  "audit_data_hash": "f8cdebe74ce0f98105d552188ff17a98cacf2645e38786549512d41d0ebc5d1e",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
@@ -90,7 +90,7 @@
       "purchased_at": "2025-02-03T12:45:30.000Z"
     },
     "buyer": {
-      "id": "b5c6d7e8-f901-4a23-9b45-6789012cdef3",
+      "id_hash": "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b",
       "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
       "identity": {
         "name": "EcoTech Solutions Inc.",

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -227,23 +227,22 @@
         "buyer": {
           "type": "object",
           "properties": {
-            "wallet_address": {
+            "id_hash": {
               "type": "string",
-              "pattern": "^0x[a-f0-9]{40}$",
-              "title": "Buyer Wallet Address",
-              "description": "Ethereum address receiving the credits",
+              "pattern": "^[0-9a-fA-F]{64}$",
+              "title": "Buyer ID Hash",
+              "description": "Anonymized pseudonymous identifier linking this buyer to off-chain records via a keyed hash",
               "examples": [
-                "0x1234567890abcdef1234567890abcdef12345678"
+                "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
               ]
             },
-            "id": {
-              "title": "Buyer ID",
-              "description": "Unique identifier for the buyer",
+            "wallet_address": {
+              "title": "Buyer Wallet Address",
+              "description": "Ethereum address receiving the credits",
               "type": "string",
-              "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
+              "pattern": "^0x[a-f0-9]{40}$",
               "examples": [
-                "ad44dd3f-f176-4b98-bf78-5ee6e77d0530"
+                "0x1234567890abcdef1234567890abcdef12345678"
               ]
             },
             "identity": {
@@ -287,11 +286,11 @@
             }
           },
           "required": [
-            "wallet_address"
+            "id_hash"
           ],
           "additionalProperties": false,
           "title": "Buyer",
-          "description": "Buyer information including wallet address, optional ID, and optional identity"
+          "description": "Buyer information including hashed identifier, optional wallet address, and optional identity"
         },
         "collections": {
           "minItems": 1,

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [
@@ -229,7 +229,7 @@
           "properties": {
             "id_hash": {
               "type": "string",
-              "pattern": "^[0-9a-fA-F]{64}$",
+              "pattern": "^[a-f0-9]{64}$",
               "title": "Buyer ID Hash",
               "description": "Anonymized pseudonymous identifier linking this buyer to off-chain records via a keyed hash",
               "examples": [
@@ -778,7 +778,7 @@
     },
     "audit_data_hash": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{64}$",
+      "pattern": "^[a-f0-9]{64}$",
       "title": "Audit Data Hash",
       "description": "SHA-256 hash of the original JSON content including private data before schema validation, used for data audit purposes",
       "examples": [

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "schema": {
-    "hash": "8d1b8a758e642217f6038d72cb43f7864fda40adecb50d9613c96d5511a49068",
+    "hash": "a9b7744c69456394e597367ad73dc6e7e4382268e71001409c8886be35a826de",
     "type": "CreditRetirementReceipt",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -231,5 +231,5 @@
       "smart_contract_address": "0x742d35cc6634c0532925a3b8d8b5c2d4c7f8e1a9"
     }
   },
-  "audit_data_hash": "5af5be3f2550f8fa82430ea53148001467eb52ce0767cd86c84260fb29e186a4"
+  "audit_data_hash": "b3f1ef0b3cc9f98a236b9fe2e886b8bca7e937d1b1153d3a0f1b7291d210a615"
 }

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "schema": {
-    "hash": "c2762646feb40d22aef26501ad33eba7024beb5cec19e559b19fce4d8d755948",
+    "hash": "8d1b8a758e642217f6038d72cb43f7864fda40adecb50d9613c96d5511a49068",
     "type": "CreditRetirementReceipt",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -83,7 +83,7 @@
       "retired_at": "2025-02-03T12:45:30.000Z"
     },
     "beneficiary": {
-      "beneficiary_id": "c3d4e5f6-a7b8-4d12-8b56-789012cdef01",
+      "id_hash": "2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c",
       "identity": {
         "name": "Climate Action Corp",
         "external_id": "d4e5f6a7-b8c9-4e23-8c67-890123def012",
@@ -91,6 +91,7 @@
       }
     },
     "credit_holder": {
+      "id_hash": "3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d",
       "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
     },
     "collections": [
@@ -230,5 +231,5 @@
       "smart_contract_address": "0x742d35cc6634c0532925a3b8d8b5c2d4c7f8e1a9"
     }
   },
-  "audit_data_hash": "86a67aeb7da1885b5861cbc71695e232c20e174e74e186abf94b5b90a50a9665"
+  "audit_data_hash": "5af5be3f2550f8fa82430ea53148001467eb52ce0767cd86c84260fb29e186a4"
 }

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
@@ -214,71 +214,20 @@
         "beneficiary": {
           "type": "object",
           "properties": {
-            "beneficiary_id": {
+            "id_hash": {
               "type": "string",
-              "format": "uuid",
-              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
-              "title": "Retirement Beneficiary ID",
-              "description": "UUID identifying the beneficiary of the retirement within the Carrot platform",
+              "pattern": "^[0-9a-fA-F]{64}$",
+              "title": "Beneficiary ID Hash",
+              "description": "Anonymized pseudonymous identifier linking this beneficiary to off-chain records via a keyed hash",
               "examples": [
-                "ad44dd3f-f176-4b98-bf78-5ee6e77d0530"
+                "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
               ]
             },
-            "identity": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "title": "Identity Name",
-                  "description": "Display name of the buyer or beneficiary on the receipt",
-                  "examples": [
-                    "EcoTech Solutions Inc.",
-                    "Climate Action Corp"
-                  ],
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 100
-                },
-                "external_id": {
-                  "title": "Identity External ID",
-                  "description": "Unique identifier of the associated entity in the Carrot platform",
-                  "type": "string",
-                  "format": "uuid",
-                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
-                  "examples": [
-                    "ad44dd3f-f176-4b98-bf78-5ee6e77d0530"
-                  ]
-                },
-                "external_url": {
-                  "title": "Identity External URL",
-                  "description": "Link to the buyer or beneficiary profile page on the Carrot platform",
-                  "type": "string",
-                  "format": "uri",
-                  "examples": [
-                    "https://explore.carrot.eco/",
-                    "https://whitepaper.carrot.eco/"
-                  ]
-                }
-              },
-              "additionalProperties": false,
-              "title": "Identity",
-              "description": "Identity information for the buyer or beneficiary associated with this receipt. All fields are optional, but at least one must be provided when the identity block is present."
-            }
-          },
-          "required": [
-            "beneficiary_id"
-          ],
-          "additionalProperties": false,
-          "title": "Beneficiary",
-          "description": "Beneficiary receiving the retirement benefit"
-        },
-        "credit_holder": {
-          "type": "object",
-          "properties": {
             "wallet_address": {
+              "title": "Beneficiary Wallet Address",
+              "description": "Ethereum address associated with the beneficiary, when available",
               "type": "string",
               "pattern": "^0x[a-f0-9]{40}$",
-              "title": "Credit Holder Wallet Address",
-              "description": "Ethereum address of the wallet that held and surrendered the credits",
               "examples": [
                 "0x1234567890abcdef1234567890abcdef12345678"
               ]
@@ -324,11 +273,79 @@
             }
           },
           "required": [
-            "wallet_address"
+            "id_hash"
+          ],
+          "additionalProperties": false,
+          "title": "Beneficiary",
+          "description": "Beneficiary receiving the retirement benefit, identified by a hashed identifier with optional wallet address and identity"
+        },
+        "credit_holder": {
+          "type": "object",
+          "properties": {
+            "id_hash": {
+              "type": "string",
+              "pattern": "^[0-9a-fA-F]{64}$",
+              "title": "Credit Holder ID Hash",
+              "description": "Anonymized pseudonymous identifier linking this credit holder to off-chain records via a keyed hash",
+              "examples": [
+                "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
+              ]
+            },
+            "wallet_address": {
+              "title": "Credit Holder Wallet Address",
+              "description": "Ethereum address of the wallet that held and surrendered the credits",
+              "type": "string",
+              "pattern": "^0x[a-f0-9]{40}$",
+              "examples": [
+                "0x1234567890abcdef1234567890abcdef12345678"
+              ]
+            },
+            "identity": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "Identity Name",
+                  "description": "Display name of the buyer or beneficiary on the receipt",
+                  "examples": [
+                    "EcoTech Solutions Inc.",
+                    "Climate Action Corp"
+                  ],
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 100
+                },
+                "external_id": {
+                  "title": "Identity External ID",
+                  "description": "Unique identifier of the associated entity in the Carrot platform",
+                  "type": "string",
+                  "format": "uuid",
+                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
+                  "examples": [
+                    "ad44dd3f-f176-4b98-bf78-5ee6e77d0530"
+                  ]
+                },
+                "external_url": {
+                  "title": "Identity External URL",
+                  "description": "Link to the buyer or beneficiary profile page on the Carrot platform",
+                  "type": "string",
+                  "format": "uri",
+                  "examples": [
+                    "https://explore.carrot.eco/",
+                    "https://whitepaper.carrot.eco/"
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "title": "Identity",
+              "description": "Identity information for the buyer or beneficiary associated with this receipt. All fields are optional, but at least one must be provided when the identity block is present."
+            }
+          },
+          "required": [
+            "id_hash"
           ],
           "additionalProperties": false,
           "title": "Credit Holder",
-          "description": "Credit holder wallet and optional identity information"
+          "description": "Credit holder information including hashed identifier, optional wallet address, and optional identity"
         },
         "collections": {
           "minItems": 1,

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [
@@ -216,7 +216,7 @@
           "properties": {
             "id_hash": {
               "type": "string",
-              "pattern": "^[0-9a-fA-F]{64}$",
+              "pattern": "^[a-f0-9]{64}$",
               "title": "Beneficiary ID Hash",
               "description": "Anonymized pseudonymous identifier linking this beneficiary to off-chain records via a keyed hash",
               "examples": [
@@ -284,7 +284,7 @@
           "properties": {
             "id_hash": {
               "type": "string",
-              "pattern": "^[0-9a-fA-F]{64}$",
+              "pattern": "^[a-f0-9]{64}$",
               "title": "Credit Holder ID Hash",
               "description": "Anonymized pseudonymous identifier linking this credit holder to off-chain records via a keyed hash",
               "examples": [
@@ -887,7 +887,7 @@
     },
     "audit_data_hash": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{64}$",
+      "pattern": "^[a-f0-9]{64}$",
       "title": "Audit Data Hash",
       "description": "SHA-256 hash of the original JSON content including private data before schema validation, used for data audit purposes",
       "examples": [

--- a/schemas/ipfs/credit/credit.example.json
+++ b/schemas/ipfs/credit/credit.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/credit/credit.schema.json",
   "schema": {
-    "hash": "1847342cd37859fe53f49ff0b2811173f55bc2d68ed8f43c32381728bd21e24f",
+    "hash": "554d97527ec5b4ebd722c07bacc7edbe74c68f87dc7adfef7d352a639d91943d",
     "type": "Credit",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"

--- a/schemas/ipfs/credit/credit.schema.json
+++ b/schemas/ipfs/credit/credit.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [

--- a/schemas/ipfs/gas-id/gas-id.example.json
+++ b/schemas/ipfs/gas-id/gas-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/gas-id/gas-id.schema.json",
   "schema": {
-    "hash": "fefdb7b4b13e4771324b8eb65fa29c0a3894a90cda6806aa46c5d95c09e60b0d",
+    "hash": "9c4fae88a8392e834328c83c604054421963fd15f33e9973faceb0f4527a8895",
     "type": "GasID",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2024-12-08T11:32:47.000Z",
   "external_id": "d2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6",
   "external_url": "https://explore.carrot.eco/document/d2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6",
-  "audit_data_hash": "42f0723788bb44372433bf0eaf1d404f1674e660af0ca2ca291e981e61b3152c",
+  "audit_data_hash": "d68ce945ddfea2f75045f7e06bff0f9b7733ad5b3b6e7900b034509f100903af",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/gas-id/gas-id.schema.json
+++ b/schemas/ipfs/gas-id/gas-id.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [
@@ -522,7 +522,7 @@
           "properties": {
             "id_hash": {
               "type": "string",
-              "pattern": "^[0-9a-fA-F]{64}$",
+              "pattern": "^[a-f0-9]{64}$",
               "title": "Location ID Hash",
               "description": "SHA-256 hash anonymizing the real location identifier for privacy",
               "examples": [
@@ -565,7 +565,7 @@
             },
             "responsible_participant_id_hash": {
               "type": "string",
-              "pattern": "^[0-9a-fA-F]{64}$",
+              "pattern": "^[a-f0-9]{64}$",
               "title": "Responsible Participant ID Hash",
               "description": "SHA-256 hash identifying the participant responsible for operations at this location",
               "examples": [
@@ -736,7 +736,7 @@
     },
     "audit_data_hash": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{64}$",
+      "pattern": "^[a-f0-9]{64}$",
       "title": "Audit Data Hash",
       "description": "SHA-256 hash of the original JSON content including private data before schema validation, used for data audit purposes",
       "examples": [

--- a/schemas/ipfs/mass-id-audit/mass-id-audit.example.json
+++ b/schemas/ipfs/mass-id-audit/mass-id-audit.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/mass-id-audit/mass-id-audit.schema.json",
   "schema": {
-    "hash": "5bbadb90250c41ef61aa1beaa7f146f3f4c7b5cba78b25f71b152624cdf8ded7",
+    "hash": "90c7ab093736c1d270b042d0c408cce084658f62904e282fa03f53887406571a",
     "type": "MassID Audit",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"

--- a/schemas/ipfs/mass-id-audit/mass-id-audit.schema.json
+++ b/schemas/ipfs/mass-id-audit/mass-id-audit.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [

--- a/schemas/ipfs/mass-id/mass-id.example.json
+++ b/schemas/ipfs/mass-id/mass-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/mass-id/mass-id.schema.json",
   "schema": {
-    "hash": "519b36aab4d590ed95161acf4472eb506b2232bbc7766b20bc8682c17f7b16e6",
+    "hash": "124b2bc466d0487125378df80586f946262b4450250744be580ed03eb1b0415a",
     "type": "MassID",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -108,7 +108,7 @@
       "display_type": "date"
     }
   ],
-  "audit_data_hash": "533746d62f7d1ba1fc1d81544267efd4bbebf74da5d0595326a861c73ed295c1",
+  "audit_data_hash": "2e45ac2b32b57a9b565cc608ea3537755a3ceeb49c9d374f79653053a7922c00",
   "data": {
     "waste_properties": {
       "type": "Organic",

--- a/schemas/ipfs/mass-id/mass-id.schema.json
+++ b/schemas/ipfs/mass-id/mass-id.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [
@@ -256,7 +256,7 @@
             "properties": {
               "id_hash": {
                 "type": "string",
-                "pattern": "^[0-9a-fA-F]{64}$",
+                "pattern": "^[a-f0-9]{64}$",
                 "title": "Location ID Hash",
                 "description": "SHA-256 hash anonymizing the real location identifier for privacy",
                 "examples": [
@@ -299,7 +299,7 @@
               },
               "responsible_participant_id_hash": {
                 "type": "string",
-                "pattern": "^[0-9a-fA-F]{64}$",
+                "pattern": "^[a-f0-9]{64}$",
                 "title": "Responsible Participant ID Hash",
                 "description": "SHA-256 hash identifying the participant responsible for operations at this location",
                 "examples": [
@@ -365,7 +365,7 @@
             "properties": {
               "id_hash": {
                 "type": "string",
-                "pattern": "^[0-9a-fA-F]{64}$",
+                "pattern": "^[a-f0-9]{64}$",
                 "title": "Participant ID Hash",
                 "description": "SHA-256 hash anonymizing the real participant identifier for privacy",
                 "examples": [
@@ -441,7 +441,7 @@
                   },
                   "participant_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Participant ID Hash",
                     "description": "SHA-256 hash anonymizing a participant identity — used to link records without exposing personal data",
                     "examples": [
@@ -450,7 +450,7 @@
                   },
                   "location_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Location ID Hash",
                     "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
@@ -541,7 +541,7 @@
                   },
                   "participant_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Participant ID Hash",
                     "description": "SHA-256 hash anonymizing a participant identity — used to link records without exposing personal data",
                     "examples": [
@@ -550,7 +550,7 @@
                   },
                   "location_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Location ID Hash",
                     "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
@@ -716,7 +716,7 @@
                   },
                   "participant_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Participant ID Hash",
                     "description": "SHA-256 hash anonymizing a participant identity — used to link records without exposing personal data",
                     "examples": [
@@ -725,7 +725,7 @@
                   },
                   "location_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Location ID Hash",
                     "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
@@ -778,7 +778,7 @@
                   },
                   "participant_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Participant ID Hash",
                     "description": "SHA-256 hash anonymizing a participant identity — used to link records without exposing personal data",
                     "examples": [
@@ -787,7 +787,7 @@
                   },
                   "location_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Location ID Hash",
                     "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
@@ -866,7 +866,7 @@
                   },
                   "participant_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Participant ID Hash",
                     "description": "SHA-256 hash anonymizing a participant identity — used to link records without exposing personal data",
                     "examples": [
@@ -875,7 +875,7 @@
                   },
                   "location_id_hash": {
                     "type": "string",
-                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "pattern": "^[a-f0-9]{64}$",
                     "title": "Location ID Hash",
                     "description": "Hash reference to the geographic location where this event occurred; matches an entry in `data.locations`",
                     "examples": [
@@ -984,7 +984,7 @@
     },
     "audit_data_hash": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{64}$",
+      "pattern": "^[a-f0-9]{64}$",
       "title": "Audit Data Hash",
       "description": "SHA-256 hash of the original JSON content including private data before schema validation, used for data audit purposes",
       "examples": [

--- a/schemas/ipfs/methodology/methodology.example.json
+++ b/schemas/ipfs/methodology/methodology.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/methodology/methodology.schema.json",
   "schema": {
-    "hash": "578345b79ca30927af7de58684a4b3a44b6ee2142c0e59e7c2798c8c75ca5ca6",
+    "hash": "041c694d8627f5b4e5699fce9217400480fdafadaae78fee21f6acc294651064",
     "type": "Methodology",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"

--- a/schemas/ipfs/methodology/methodology.schema.json
+++ b/schemas/ipfs/methodology/methodology.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [

--- a/schemas/ipfs/recycled-id/recycled-id.example.json
+++ b/schemas/ipfs/recycled-id/recycled-id.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/0.5.1/schemas/ipfs/recycled-id/recycled-id.schema.json",
   "schema": {
-    "hash": "ed9e7eda88b26b15d10352bea039e6325951c0b30c1d908e71b402a2b3277861",
+    "hash": "4fdd7799f74644bc5d5b8551b7841071c0bad8430468d28a3c445ff4e9c3d05d",
     "type": "RecycledID",
     "version": "0.5.1",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2024-12-08T11:32:47.000Z",
   "external_id": "f47ac10b-58cc-4372-a567-0e02b2c3d489",
   "external_url": "https://explore.carrot.eco/document/f47ac10b-58cc-4372-a567-0e02b2c3d489",
-  "audit_data_hash": "5793faa54fec5c96ef2fcafabaf5dc25bcb110773ac56cba30dd31cda1d577e5",
+  "audit_data_hash": "e036b6b559cbb74373e2d9da2c2f9233fc2c7a0e537fd14c4016d3fa52f90c36",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/recycled-id/recycled-id.schema.json
+++ b/schemas/ipfs/recycled-id/recycled-id.schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Schema Hash",
           "description": "SHA-256 hash of the JSON Schema this record was validated against",
           "examples": [
@@ -105,7 +105,7 @@
         },
         "integrity_hash": {
           "type": "string",
-          "pattern": "^[0-9a-fA-F]{64}$",
+          "pattern": "^[a-f0-9]{64}$",
           "title": "Viewer Integrity Hash",
           "description": "SHA-256 hash of the published viewer bundle to verify integrity",
           "examples": [
@@ -510,7 +510,7 @@
           "properties": {
             "id_hash": {
               "type": "string",
-              "pattern": "^[0-9a-fA-F]{64}$",
+              "pattern": "^[a-f0-9]{64}$",
               "title": "Location ID Hash",
               "description": "SHA-256 hash anonymizing the real location identifier for privacy",
               "examples": [
@@ -553,7 +553,7 @@
             },
             "responsible_participant_id_hash": {
               "type": "string",
-              "pattern": "^[0-9a-fA-F]{64}$",
+              "pattern": "^[a-f0-9]{64}$",
               "title": "Responsible Participant ID Hash",
               "description": "SHA-256 hash identifying the participant responsible for operations at this location",
               "examples": [
@@ -623,7 +623,7 @@
     },
     "audit_data_hash": {
       "type": "string",
-      "pattern": "^[0-9a-fA-F]{64}$",
+      "pattern": "^[a-f0-9]{64}$",
       "title": "Audit Data Hash",
       "description": "SHA-256 hash of the original JSON content including private data before schema validation, used for data audit purposes",
       "examples": [

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -22,11 +22,11 @@
       "path": "ipfs/gas-id/gas-id.schema.json"
     },
     "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json": {
-      "hash": "c2762646feb40d22aef26501ad33eba7024beb5cec19e559b19fce4d8d755948",
+      "hash": "8d1b8a758e642217f6038d72cb43f7864fda40adecb50d9613c96d5511a49068",
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "bc9882d5b3da7f685798b9e9c7757fddcf1cbe7f9fd6584c176d10b96a722219",
+      "hash": "2343c61b35d66f24a5bc6f2bb7d070415a5f8b4d8b54b870b4e5d496e69fa75b",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -2,39 +2,39 @@
   "version": "0.5.1",
   "schemas": {
     "ipfs/recycled-id/recycled-id.schema.json": {
-      "hash": "ed9e7eda88b26b15d10352bea039e6325951c0b30c1d908e71b402a2b3277861",
+      "hash": "4fdd7799f74644bc5d5b8551b7841071c0bad8430468d28a3c445ff4e9c3d05d",
       "path": "ipfs/recycled-id/recycled-id.schema.json"
     },
     "ipfs/methodology/methodology.schema.json": {
-      "hash": "578345b79ca30927af7de58684a4b3a44b6ee2142c0e59e7c2798c8c75ca5ca6",
+      "hash": "041c694d8627f5b4e5699fce9217400480fdafadaae78fee21f6acc294651064",
       "path": "ipfs/methodology/methodology.schema.json"
     },
     "ipfs/mass-id-audit/mass-id-audit.schema.json": {
-      "hash": "5bbadb90250c41ef61aa1beaa7f146f3f4c7b5cba78b25f71b152624cdf8ded7",
+      "hash": "90c7ab093736c1d270b042d0c408cce084658f62904e282fa03f53887406571a",
       "path": "ipfs/mass-id-audit/mass-id-audit.schema.json"
     },
     "ipfs/mass-id/mass-id.schema.json": {
-      "hash": "519b36aab4d590ed95161acf4472eb506b2232bbc7766b20bc8682c17f7b16e6",
+      "hash": "124b2bc466d0487125378df80586f946262b4450250744be580ed03eb1b0415a",
       "path": "ipfs/mass-id/mass-id.schema.json"
     },
     "ipfs/gas-id/gas-id.schema.json": {
-      "hash": "fefdb7b4b13e4771324b8eb65fa29c0a3894a90cda6806aa46c5d95c09e60b0d",
+      "hash": "9c4fae88a8392e834328c83c604054421963fd15f33e9973faceb0f4527a8895",
       "path": "ipfs/gas-id/gas-id.schema.json"
     },
     "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json": {
-      "hash": "8d1b8a758e642217f6038d72cb43f7864fda40adecb50d9613c96d5511a49068",
+      "hash": "a9b7744c69456394e597367ad73dc6e7e4382268e71001409c8886be35a826de",
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "2343c61b35d66f24a5bc6f2bb7d070415a5f8b4d8b54b870b4e5d496e69fa75b",
+      "hash": "6d61ee689ef2a5ab52b9727f60288905ba3e7a282c27080d342229e3344e0521",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {
-      "hash": "1847342cd37859fe53f49ff0b2811173f55bc2d68ed8f43c32381728bd21e24f",
+      "hash": "554d97527ec5b4ebd722c07bacc7edbe74c68f87dc7adfef7d352a639d91943d",
       "path": "ipfs/credit/credit.schema.json"
     },
     "ipfs/collection/collection.schema.json": {
-      "hash": "ac9ab55eb672748c69c3421259fffa7e6257f080d2e722859085b245cf226f91",
+      "hash": "fefd645f1167494243989ecebe6db02b5f9d338373fe741a53902ab785dc39ee",
       "path": "ipfs/collection/collection.schema.json"
     }
   }

--- a/scripts/example-content/emitters/credit-purchase-receipt.ts
+++ b/scripts/example-content/emitters/credit-purchase-receipt.ts
@@ -117,7 +117,8 @@ export function emitCreditPurchaseReceiptExample(): Record<string, unknown> {
         purchased_at: formatDateTime(purchasedAt),
       },
       buyer: {
-        id: 'b5c6d7e8-f901-4a23-9b45-6789012cdef3',
+        id_hash:
+          '1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b',
         wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
         identity: {
           name: 'EcoTech Solutions Inc.',

--- a/scripts/example-content/emitters/credit-retirement-receipt.ts
+++ b/scripts/example-content/emitters/credit-retirement-receipt.ts
@@ -110,7 +110,8 @@ export function emitCreditRetirementReceiptExample(): Record<string, unknown> {
         retired_at: formatDateTime(retiredAt),
       },
       beneficiary: {
-        beneficiary_id: 'c3d4e5f6-a7b8-4d12-8b56-789012cdef01',
+        id_hash:
+          '2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c',
         identity: {
           name: 'Climate Action Corp',
           external_id: 'd4e5f6a7-b8c9-4e23-8c67-890123def012',
@@ -119,6 +120,8 @@ export function emitCreditRetirementReceiptExample(): Record<string, unknown> {
         },
       },
       credit_holder: {
+        id_hash:
+          '3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d',
         wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
       },
       collections: [

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
@@ -123,6 +123,34 @@ describe('CreditPurchaseReceiptDataSchema', () => {
     });
   });
 
+  it('requires buyer.id_hash', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      Reflect.deleteProperty(
+        invalid.buyer as Record<string, unknown>,
+        'id_hash',
+      );
+    });
+  });
+
+  it('rejects buyer.id_hash that is not a SHA-256 hex string', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      (invalid.buyer as Record<string, unknown>).id_hash =
+        'b5c6d7e8-f901-4a23-9b45-6789012cdef3';
+    });
+  });
+
+  it('allows buyer.wallet_address to be omitted', () => {
+    expectSchemaValid(schema, () => {
+      const valid = structuredClone(baseData);
+      Reflect.deleteProperty(
+        valid.buyer as Record<string, unknown>,
+        'wallet_address',
+      );
+
+      return valid;
+    });
+  });
+
   it('rejects certificate collection retired_amount greater than purchased_amount', () => {
     expectSchemaInvalid(schema, baseData, (invalid) => {
       invalid.certificates[0].collections[0].retired_amount =

--- a/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
+++ b/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import {
-  ExternalIdSchema,
   uniqueBy,
   CreditPurchaseReceiptSummarySchema,
   ReceiptIdentitySchema,
@@ -18,6 +17,7 @@ import {
 import {
   CreditTokenSlugSchema,
   EthereumAddressSchema,
+  Sha256HashSchema,
 } from '../shared/schemas/primitives';
 
 const CreditPurchaseReceiptIdentitySchema = ReceiptIdentitySchema;
@@ -27,20 +27,21 @@ export type CreditPurchaseReceiptIdentity = z.infer<
 
 const CreditPurchaseReceiptBuyerSchema = z
   .strictObject({
-    wallet_address: EthereumAddressSchema.meta({
+    id_hash: Sha256HashSchema.meta({
+      title: 'Buyer ID Hash',
+      description:
+        'Anonymized pseudonymous identifier linking this buyer to off-chain records via a keyed hash',
+    }),
+    wallet_address: EthereumAddressSchema.optional().meta({
       title: 'Buyer Wallet Address',
       description: 'Ethereum address receiving the credits',
-    }),
-    id: ExternalIdSchema.optional().meta({
-      title: 'Buyer ID',
-      description: 'Unique identifier for the buyer',
     }),
     identity: CreditPurchaseReceiptIdentitySchema.optional(),
   })
   .meta({
     title: 'Buyer',
     description:
-      'Buyer information including wallet address, optional ID, and optional identity',
+      'Buyer information including hashed identifier, optional wallet address, and optional identity',
   });
 export type CreditPurchaseReceiptBuyer = z.infer<
   typeof CreditPurchaseReceiptBuyerSchema

--- a/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.data.schema.spec.ts
+++ b/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.data.schema.spec.ts
@@ -128,6 +128,60 @@ describe('CreditRetirementReceiptDataSchema', () => {
     });
   });
 
+  it('requires beneficiary.id_hash', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      Reflect.deleteProperty(
+        invalid.beneficiary as Record<string, unknown>,
+        'id_hash',
+      );
+    });
+  });
+
+  it('rejects beneficiary.id_hash that is not a SHA-256 hex string', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      (invalid.beneficiary as Record<string, unknown>).id_hash =
+        'c3d4e5f6-a7b8-4d12-8b56-789012cdef01';
+    });
+  });
+
+  it('allows beneficiary.wallet_address when a valid Ethereum address', () => {
+    expectSchemaValid(schema, () => {
+      const valid = structuredClone(baseData);
+      (valid.beneficiary as Record<string, unknown>).wallet_address =
+        '0x742d35cc6634c0532925a3b8d8b5c2d4c7f8e1a9';
+
+      return valid;
+    });
+  });
+
+  it('requires credit_holder.id_hash', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      Reflect.deleteProperty(
+        invalid.credit_holder as Record<string, unknown>,
+        'id_hash',
+      );
+    });
+  });
+
+  it('rejects credit_holder.id_hash that is not a SHA-256 hex string', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      (invalid.credit_holder as Record<string, unknown>).id_hash =
+        'not-a-valid-hash';
+    });
+  });
+
+  it('allows credit_holder.wallet_address to be omitted', () => {
+    expectSchemaValid(schema, () => {
+      const valid = structuredClone(baseData);
+      Reflect.deleteProperty(
+        valid.credit_holder as Record<string, unknown>,
+        'wallet_address',
+      );
+
+      return valid;
+    });
+  });
+
   it('rejects collection with zero retired total', () => {
     expectSchemaInvalid(schema, baseData, (invalid) => {
       invalid.collections.push({

--- a/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
+++ b/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
@@ -16,6 +16,7 @@ import {
   validateTotalMatches,
   CreditTokenSlugSchema,
   EthereumAddressSchema,
+  Sha256HashSchema,
   validateCertificateCollectionSlugs,
   validateCollectionsHaveRetiredAmounts,
   validateCreditSlugExists,
@@ -30,16 +31,22 @@ export type CreditRetirementReceiptIdentity = z.infer<
 
 const CreditRetirementReceiptBeneficiarySchema = z
   .strictObject({
-    beneficiary_id: ExternalIdSchema.meta({
-      title: 'Retirement Beneficiary ID',
+    id_hash: Sha256HashSchema.meta({
+      title: 'Beneficiary ID Hash',
       description:
-        'UUID identifying the beneficiary of the retirement within the Carrot platform',
+        'Anonymized pseudonymous identifier linking this beneficiary to off-chain records via a keyed hash',
+    }),
+    wallet_address: EthereumAddressSchema.optional().meta({
+      title: 'Beneficiary Wallet Address',
+      description:
+        'Ethereum address associated with the beneficiary, when available',
     }),
     identity: CreditRetirementReceiptIdentitySchema.optional(),
   })
   .meta({
     title: 'Beneficiary',
-    description: 'Beneficiary receiving the retirement benefit',
+    description:
+      'Beneficiary receiving the retirement benefit, identified by a hashed identifier with optional wallet address and identity',
   });
 export type CreditRetirementReceiptBeneficiary = z.infer<
   typeof CreditRetirementReceiptBeneficiarySchema
@@ -47,7 +54,12 @@ export type CreditRetirementReceiptBeneficiary = z.infer<
 
 const CreditRetirementReceiptCreditHolderSchema = z
   .strictObject({
-    wallet_address: EthereumAddressSchema.meta({
+    id_hash: Sha256HashSchema.meta({
+      title: 'Credit Holder ID Hash',
+      description:
+        'Anonymized pseudonymous identifier linking this credit holder to off-chain records via a keyed hash',
+    }),
+    wallet_address: EthereumAddressSchema.optional().meta({
       title: 'Credit Holder Wallet Address',
       description:
         'Ethereum address of the wallet that held and surrendered the credits',
@@ -56,7 +68,8 @@ const CreditRetirementReceiptCreditHolderSchema = z
   })
   .meta({
     title: 'Credit Holder',
-    description: 'Credit holder wallet and optional identity information',
+    description:
+      'Credit holder information including hashed identifier, optional wallet address, and optional identity',
   });
 export type CreditRetirementReceiptCreditHolder = z.infer<
   typeof CreditRetirementReceiptCreditHolderSchema

--- a/src/shared/schemas/primitives/__tests__/hashes.schema.spec.ts
+++ b/src/shared/schemas/primitives/__tests__/hashes.schema.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { ParticipantIdHashSchema, Sha256HashSchema } from '../hashes.schema';
+
+describe('Sha256HashSchema', () => {
+  const lowercaseHash =
+    '87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489';
+
+  it('accepts a canonical lowercase 64-char hex string', () => {
+    const result = Sha256HashSchema.safeParse(lowercaseHash);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an uppercase hex string', () => {
+    const result = Sha256HashSchema.safeParse(lowercaseHash.toUpperCase());
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a mixed-case hex string', () => {
+    const mixed = `${lowercaseHash.slice(0, 32).toUpperCase()}${lowercaseHash.slice(32)}`;
+
+    const result = Sha256HashSchema.safeParse(mixed);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a string with a 0x prefix', () => {
+    const result = Sha256HashSchema.safeParse(`0x${lowercaseHash.slice(2)}`);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-hex character', () => {
+    const result = Sha256HashSchema.safeParse(`${lowercaseHash.slice(0, 63)}z`);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a hash shorter than 64 characters', () => {
+    const result = Sha256HashSchema.safeParse(lowercaseHash.slice(0, 63));
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a hash longer than 64 characters', () => {
+    const result = Sha256HashSchema.safeParse(`${lowercaseHash}0`);
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ParticipantIdHashSchema', () => {
+  it('accepts the same canonical lowercase format as Sha256HashSchema', () => {
+    const hash =
+      '87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489';
+
+    const result = ParticipantIdHashSchema.safeParse(hash);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an uppercase hex string', () => {
+    const hash =
+      '87F633634CC4B02F628685651F0A29B7BFA22A0BD841F725C6772DD00A58D489';
+
+    const result = ParticipantIdHashSchema.safeParse(hash);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/shared/schemas/primitives/hashes.schema.ts
+++ b/src/shared/schemas/primitives/hashes.schema.ts
@@ -1,13 +1,15 @@
 import { z } from 'zod';
 
 export const Sha256HashSchema = z
-  .hash('sha256', {
-    error: 'Must be a SHA256 hash as 32-byte hex string',
+  .string()
+  .regex(/^[a-f0-9]{64}$/, {
+    error:
+      'Must be a SHA-256 hash as 32-byte lowercase hex string (no 0x prefix)',
   })
   .meta({
-    format: undefined,
     title: 'SHA-256 Hash',
-    description: 'SHA-256 cryptographic hash as hexadecimal string',
+    description:
+      'SHA-256 cryptographic hash as canonical lowercase hexadecimal string',
     examples: [
       '87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489',
     ],


### PR DESCRIPTION
## Breaking changes

This PR ships breaking changes at the TypeScript level on `CreditPurchaseReceipt` and `CreditRetirementReceipt` IPFS payloads. `@carrot-foundation/schemas` 0.5.0 → 0.6.0 (minor under 0.x; semantic-release will bump on merge).

| Before | After |
|---|---|
| `buyer.id: ExternalId` (optional) | `buyer.id_hash: Sha256Hash` (required) |
| `beneficiary.beneficiary_id: ExternalId` (required) | `beneficiary.id_hash: Sha256Hash` (required) |
| `credit_holder` had no id field | `credit_holder.id_hash: Sha256Hash` (required, new) |
| `buyer.wallet_address` required | `buyer.wallet_address` optional |
| `credit_holder.wallet_address` required | `credit_holder.wallet_address` optional |
| `beneficiary` had no wallet field | `beneficiary.wallet_address` optional (new) |

Consumers typed against 0.5.0 must update. `ReceiptIdentitySchema` itself is unchanged — `name`, `external_id`, `external_url` stay optional, with the existing "at least one present" refine.

### 🧾 Summary

Replaces raw participant identifiers on credit receipts with keyed SHA-256 hashes, and gives the three identity-bearing blocks (`buyer`, `beneficiary`, `credit_holder`) a single uniform shape `{ id_hash, wallet_address?, identity? }` so consumers (Explorer, viewer) can treat them symmetrically.

### 🧩 Context

**Why this change?** On-chain credit receipt NFTs currently carry raw participant identifiers (UUIDs). These are PII-adjacent and cannot be rotated once minted. The hashing design preserves off-chain de-para (via token + role-scoped HMAC-SHA-256 computed in smaug by `KmsHmacService`) while removing the stable identifier from the on-chain record.

**Problem it solves:** (1) privacy — no raw participant UUIDs on-chain; (2) schema symmetry — all three identity-bearing blocks now share one shape so consumers don't branch per role.

**Business value:** unblocks CRT-382 tokenization follow-ups and CRT-376 identity separation.

### 🧱 Scope of this PR

**This PR includes:**

- [x] New features (uniform `id_hash` field on three blocks; new optional `beneficiary.wallet_address`)
- [x] Bug fixes (N/A — no bugs)
- [x] Refactoring (renames + re-typing on existing blocks)
- [x] Documentation updates (meta descriptions updated on affected fields/blocks)
- [ ] Configuration changes

**Intentionally excluded** _(to be addressed in future PRs):_

- The HMAC computation itself (lives in smaug `KmsHmacService.hashSha256` — separate PR, stacks on this one for the 0.6.0 consumer bump).
- MassID hashing alignment with the new token+role scoping (separate follow-up ticket).
- Receipt identity `external_id` / `external_url` population by Explorer / buyer-viewer (no schema change needed — both already optional).

### 🚨 Breaking Changes & Migration

See the **Breaking changes** block at the top. Migration for smaug (tracked in CRT-382 smaug PR):

1. Bump `@carrot-foundation/schemas` to `0.6.0`.
2. Replace `buyer.id` writes with `buyer.id_hash` computed via `KmsHmacService.hashSha256` with input `${sourceId}:${tokenId}:${role}`.
3. Replace `beneficiary.beneficiary_id` writes with `beneficiary.id_hash` (same helper, `role = 'beneficiary'`).
4. Add `credit_holder.id_hash` writes (same helper, `role = 'credit_holder'`).
5. Make `wallet_address` writes conditional on availability for buyer / credit_holder; populate on beneficiary when an address is known.

No production data migration needed — no credit receipt NFTs minted in production yet (parent tokenization work still in review).

### 🧪 How to test

```bash
pnpm check        # full gate: lint, format, type-check, spell-check, pkgJsonLint,
                  # generate, hash, update-examples, validate-schemas,
                  # verify-versions, check-refs, validate-examples, test,
                  # knip, license-check, size-limit, publint, attw, ai:check
pnpm test:coverage  # 100% across statements / branches / functions / lines
```

Added spec coverage on the new shape:

- `src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts` — `buyer.id_hash` required; rejects non-hex `id_hash`; `buyer.wallet_address` optional.
- `src/credit-retirement-receipt/__tests__/credit-retirement-receipt.data.schema.spec.ts` — same matrix on `beneficiary` and `credit_holder`.

### 📦 Deployment Notes

- `@carrot-foundation/schemas` 0.6.0 publishes automatically on merge via semantic-release. The consumer bump in smaug lands in the CRT-382 smaug PR, which stacks on this one and waits for the 0.6.0 dist-tag.
- No schema de-para roundtrip spec lives in this repo (no KMS key access). The executable contract test lives on the smaug side with a deterministic stubbed key.

### 🧠 Considerations for Review

**Focus areas for review:**

- [x] Business logic correctness (the three `id_hash` descriptions are general-purpose; no MVP / implementation / ticket refs per CRT-381 feedback)
- [x] Security implications (removing raw UUIDs from on-chain receipts; hashing happens in smaug via KMS-HMAC — rotation disabled by design)
- [ ] Performance impact (N/A — shape-only schema change)
- [x] API design (uniform `{ id_hash, wallet_address?, identity? }` across buyer / beneficiary / credit_holder)
- [x] Test coverage (100% maintained)

**Key files to review:**

- `src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts` — buyer block reshape
- `src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts` — beneficiary + credit_holder block reshape
- `scripts/example-content/emitters/credit-{purchase,retirement}-receipt.ts` — example data updated to the new shape (source of truth for `*.example.json`)
- `schemas/ipfs/credit-{purchase,retirement}-receipt/*.json` — regenerated artifacts (do not edit manually)

### 🔗 Related Links

- ClickUp: [CRT-382](https://app.clickup.com/t/86ah1bex8)
- Related: CRT-381 (IPFS description audit — this PR's field descriptions follow that style)
- Related: CRT-376 (identity separation — unblocked once this lands)
- Stacks with: smaug CRT-382 PR (waits for 0.6.0)

---

### ✅ Pre-merge Checklist

#### Code Quality

- [x] Code follows project style guidelines and naming conventions
- [x] All new code has appropriate test coverage (100% maintained)
- [x] Linter warnings and errors have been resolved
- [x] No debugging code or console logs remain

#### Review & Testing

- [x] Self-review completed with focus on edge cases (shape validation, hex format, optional branching)
- [x] Manual testing performed in appropriate environment (`pnpm check` + `pnpm test:coverage` green locally)
- [x] Breaking changes clearly identified and justified
- [x] All tests pass locally (649/649)

#### Final Confirmation

- [x] **I confirm this PR works as expected, follows best practices, and improves codebase quality**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking schema changes to `CreditPurchaseReceipt` and `CreditRetirementReceipt` payload shapes (required `id_hash`, optional wallet fields) may require coordinated consumer updates and could reject previously-valid receipt data.
> 
> **Overview**
> **Credit receipt schemas now use hashed participant identifiers.** `CreditPurchaseReceipt.data.buyer` replaces the prior participant identifier with required `id_hash` and makes `wallet_address` optional; `CreditRetirementReceipt` similarly requires `beneficiary.id_hash` and introduces required `credit_holder.id_hash`, with optional `wallet_address` for both.
> 
> **Hash validation is standardized and stricter.** `Sha256HashSchema` is redefined to require canonical lowercase 64-char hex (no `0x`), new primitive tests are added, and all affected JSON Schemas/examples (plus `schema-hashes.json` and example emitters) are regenerated with updated patterns and values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8563f961b00dce81e5e75c2348d404059b7cc34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->