### PR TITLE
feat(credit-receipts)!: support no-collection variant

### DIFF
--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "6192619b85c846393b8ccc06d8b0875992c00e490eb2a3a2800a3b834a7a31a2",
+    "hash": "78b4268591fd349333cc6e9074e07873c78507423b96eab6c9d7a09beefeb2fa",
     "type": "CreditPurchaseReceipt",
     "version": "1.0.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "363d8881fb95a4d8bac5a5d48d48c5d120b21e10ed25b1c1da394d790502eafa",
+  "audit_data_hash": "e56a8ddd178ee0185ceb65307bc0475575c98caa7b5f438adbf2c3f77d85b619",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "99b2afe08b02193a66628e0f7a197bcb8747e975f743dafbe9e09543d6ddde24",
+    "hash": "5c5b9ff4f0cc657570699c120e8028b87ae95f00a318ccd9349fabc800dee10a",
     "type": "CreditPurchaseReceipt",
     "version": "1.0.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "70fd6a769d06de22eb86c8473aee5a384bed761b4e615797d1a701a9cf0c88b0",
+  "audit_data_hash": "cb85f87a032084940f7a59870450f650e0c601b285abc7151c6729ba7e82a318",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "78b4268591fd349333cc6e9074e07873c78507423b96eab6c9d7a09beefeb2fa",
+    "hash": "99b2afe08b02193a66628e0f7a197bcb8747e975f743dafbe9e09543d6ddde24",
     "type": "CreditPurchaseReceipt",
     "version": "1.0.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "e56a8ddd178ee0185ceb65307bc0475575c98caa7b5f438adbf2c3f77d85b619",
+  "audit_data_hash": "70fd6a769d06de22eb86c8473aee5a384bed761b4e615797d1a701a9cf0c88b0",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "schema": {
-    "hash": "baf3544f11c71c86c2187af967635ccf1ffdddd70cb14365f44d08a32bc3d1f7",
+    "hash": "6192619b85c846393b8ccc06d8b0875992c00e490eb2a3a2800a3b834a7a31a2",
     "type": "CreditPurchaseReceipt",
     "version": "1.0.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -20,7 +20,7 @@
   "created_at": "2025-02-03T12:45:30.000Z",
   "external_id": "f1a2b3c4-d5e6-4789-9012-34567890abcd",
   "external_url": "https://explore.carrot.eco/document/f1a2b3c4-d5e6-4789-9012-34567890abcd",
-  "audit_data_hash": "7c06a05937239797c8f8dedf99fe59d799fd54577bff6c887bdffdb94958d7c3",
+  "audit_data_hash": "363d8881fb95a4d8bac5a5d48d48c5d120b21e10ed25b1c1da394d790502eafa",
   "viewer_reference": {
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm",
     "integrity_hash": "87f633634cc4b02f628685651f0a29b7bfa22a0bd841f725c6772dd00a58d489"
@@ -137,6 +137,7 @@
         "type": "GasID",
         "token_id": "200001",
         "total_amount": 10,
+        "purchased_amount": 3,
         "credit_slug": "carbon-methane",
         "external_id": "d2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6",
         "external_url": "https://explore.carrot.eco/document/d2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6",
@@ -161,6 +162,7 @@
         "type": "RecycledID",
         "token_id": "300001",
         "total_amount": 6,
+        "purchased_amount": 2,
         "credit_slug": "biowaste",
         "external_id": "f47ac10b-58cc-4372-a567-0e02b2c3d489",
         "external_url": "https://explore.carrot.eco/document/f47ac10b-58cc-4372-a567-0e02b2c3d489",
@@ -185,6 +187,7 @@
         "type": "RecycledID",
         "token_id": "890",
         "total_amount": 8,
+        "purchased_amount": 3.5,
         "credit_slug": "biowaste",
         "external_id": "0f1e2d3c-4b5a-4d78-8c12-3456789abcde",
         "external_url": "https://explore.carrot.eco/document/0f1e2d3c-4b5a-4d78-8c12-3456789abcde",

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -194,9 +194,9 @@
             },
             "total_credits": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Total Credits",
-              "description": "Total number of environmental impact credits purchased in this transaction",
+              "description": "Total number of environmental impact credits purchased in this transaction. Must be greater than 0.",
               "examples": [
                 1.5,
                 100,

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -293,7 +293,6 @@
           "description": "Buyer information including hashed identifier, optional wallet address, and optional identity"
         },
         "collections": {
-          "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
@@ -372,7 +371,7 @@
             "description": "Collection included in the purchase"
           },
           "title": "Collections",
-          "description": "Impact collections referenced by this purchase, each identified by a unique slug"
+          "description": "Impact collections referenced by this purchase, each identified by a unique slug. May be empty when no certificate is assigned to a collection."
         },
         "credits": {
           "minItems": 1,

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -622,8 +622,18 @@
                   "biowaste"
                 ]
               },
+              "purchased_amount": {
+                "type": "number",
+                "minimum": 0,
+                "title": "Certificate Purchased Amount",
+                "description": "Total credits purchased from this certificate. Authoritative source for receipt totals; cross-checked against sum(collections[].purchased_amount) when collections are non-empty.",
+                "examples": [
+                  1.5,
+                  100,
+                  2500.75
+                ]
+              },
               "collections": {
-                "minItems": 1,
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -676,7 +686,7 @@
                   "description": "Collection reference with purchased and retired amounts for a certificate in a purchase receipt"
                 },
                 "title": "Certificate Collections",
-                "description": "Collections associated with this certificate, each with purchased and retired amounts"
+                "description": "Collections associated with this certificate, each with purchased and retired amounts. May be empty when this certificate is not assigned to any collection."
               }
             },
             "required": [
@@ -689,6 +699,7 @@
               "total_amount",
               "mass_id",
               "credit_slug",
+              "purchased_amount",
               "collections"
             ],
             "additionalProperties": false,

--- a/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
+++ b/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json
@@ -1323,7 +1323,7 @@
   ],
   "additionalProperties": false,
   "title": "CreditPurchaseReceipt NFT IPFS Record",
-  "description": "Complete CreditPurchaseReceipt NFT IPFS record including purchase summary, buyer details, credit breakdowns, certificate allocations, and NFT display attributes",
+  "description": "Complete CreditPurchaseReceipt NFT IPFS record including purchase summary, buyer details, credit breakdowns, certificate allocations, and NFT display attributes. Supports both collection-assigned and no-collection variants.",
   "$id": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json",
   "version": "1.0.0"
 }

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "schema": {
-    "hash": "97be61b98ffdbb4e3054c137f36cfbe9d94f9d5d28436c44cc11d19d36c8fd44",
+    "hash": "e21c90d2b781098165ceaea8e23f87376556e8b8fca0fee3ed5d5416506bb9ac",
     "type": "CreditRetirementReceipt",
     "version": "1.0.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -231,5 +231,5 @@
       "smart_contract_address": "0x742d35cc6634c0532925a3b8d8b5c2d4c7f8e1a9"
     }
   },
-  "audit_data_hash": "4c18fc2b3fac394dde6624af43e79797fa4d3241d5c8bbc1a153a0cd49c21315"
+  "audit_data_hash": "a5742904c5e6b9e01c795cb83a1b2f726cb9b8d0bc3cdc487c03da44d001b646"
 }

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "schema": {
-    "hash": "343a22f6bd51a89b8a6ca83c5136938a2bd3e3c1b42645d05216476085d28d06",
+    "hash": "882cdddf6158a56bae8b41b3cd07db27a9e6a37efbf98c2a637ec2a8a8e38c5a",
     "type": "CreditRetirementReceipt",
     "version": "1.0.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -231,5 +231,5 @@
       "smart_contract_address": "0x742d35cc6634c0532925a3b8d8b5c2d4c7f8e1a9"
     }
   },
-  "audit_data_hash": "c3a15edddd68e15a5bfaa82ce6be5c131d433b23858e8511f1724fe75c3fde5e"
+  "audit_data_hash": "56c699d657920ae58109fa5811fe3c32248138a8053d0fcef7f2dd89c8f66f73"
 }

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.example.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "schema": {
-    "hash": "882cdddf6158a56bae8b41b3cd07db27a9e6a37efbf98c2a637ec2a8a8e38c5a",
+    "hash": "97be61b98ffdbb4e3054c137f36cfbe9d94f9d5d28436c44cc11d19d36c8fd44",
     "type": "CreditRetirementReceipt",
     "version": "1.0.0",
     "ipfs_uri": "ipfs://bafybeigdyrztvzl5cceubvaxob7iqh6f3f7s36c74ojav2xsz2uib2g3vm"
@@ -231,5 +231,5 @@
       "smart_contract_address": "0x742d35cc6634c0532925a3b8d8b5c2d4c7f8e1a9"
     }
   },
-  "audit_data_hash": "56c699d657920ae58109fa5811fe3c32248138a8053d0fcef7f2dd89c8f66f73"
+  "audit_data_hash": "4c18fc2b3fac394dde6624af43e79797fa4d3241d5c8bbc1a153a0cd49c21315"
 }

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
@@ -348,7 +348,6 @@
           "description": "Credit holder information including hashed identifier, optional wallet address, and optional identity"
         },
         "collections": {
-          "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
@@ -427,7 +426,7 @@
             "description": "Collection included in the retirement"
           },
           "title": "Collections",
-          "description": "Impact collections referenced by this retirement, each identified by a unique slug"
+          "description": "Impact collections referenced by this retirement, each identified by a unique slug. May be empty when no certificate is assigned to a collection."
         },
         "credits": {
           "minItems": 1,
@@ -665,7 +664,6 @@
                 "description": "Reference to a MassID record"
               },
               "collections": {
-                "minItems": 1,
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -706,7 +704,7 @@
                   "description": "Collection reference with retired amount for a certificate in a retirement receipt"
                 },
                 "title": "Certificate Collections",
-                "description": "Collections associated with this certificate, each with retired amounts"
+                "description": "Collections associated with this certificate, each with retired amounts. May be empty when this certificate is not assigned to any collection."
               },
               "credits_retired": {
                 "minItems": 1,

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
@@ -182,9 +182,9 @@
             },
             "total_credits_retired": {
               "type": "number",
-              "minimum": 0,
+              "exclusiveMinimum": 0,
               "title": "Total Credits Retired",
-              "description": "Total number of environmental impact credits permanently retired (removed from circulation)",
+              "description": "Total number of environmental impact credits permanently retired (removed from circulation). Must be greater than 0.",
               "examples": [
                 1.5,
                 100,

--- a/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
+++ b/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json
@@ -1447,7 +1447,7 @@
   ],
   "additionalProperties": false,
   "title": "CreditRetirementReceipt NFT IPFS Record",
-  "description": "Complete CreditRetirementReceipt NFT IPFS record including retirement summary, beneficiary and credit holder details (identity optional), credit breakdowns, certificate allocations, and NFT display attributes",
+  "description": "Complete CreditRetirementReceipt NFT IPFS record including retirement summary, beneficiary and credit holder details (identity optional), credit breakdowns, certificate allocations, and NFT display attributes. Supports both collection-assigned and no-collection variants.",
   "$id": "https://raw.githubusercontent.com/carrot-foundation/schemas/refs/tags/1.0.0/schemas/ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json",
   "version": "1.0.0"
 }

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -26,7 +26,7 @@
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "78b4268591fd349333cc6e9074e07873c78507423b96eab6c9d7a09beefeb2fa",
+      "hash": "99b2afe08b02193a66628e0f7a197bcb8747e975f743dafbe9e09543d6ddde24",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -26,7 +26,7 @@
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "6192619b85c846393b8ccc06d8b0875992c00e490eb2a3a2800a3b834a7a31a2",
+      "hash": "78b4268591fd349333cc6e9074e07873c78507423b96eab6c9d7a09beefeb2fa",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -22,7 +22,7 @@
       "path": "ipfs/gas-id/gas-id.schema.json"
     },
     "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json": {
-      "hash": "882cdddf6158a56bae8b41b3cd07db27a9e6a37efbf98c2a637ec2a8a8e38c5a",
+      "hash": "97be61b98ffdbb4e3054c137f36cfbe9d94f9d5d28436c44cc11d19d36c8fd44",
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -26,7 +26,7 @@
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "baf3544f11c71c86c2187af967635ccf1ffdddd70cb14365f44d08a32bc3d1f7",
+      "hash": "6192619b85c846393b8ccc06d8b0875992c00e490eb2a3a2800a3b834a7a31a2",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -22,11 +22,11 @@
       "path": "ipfs/gas-id/gas-id.schema.json"
     },
     "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json": {
-      "hash": "97be61b98ffdbb4e3054c137f36cfbe9d94f9d5d28436c44cc11d19d36c8fd44",
+      "hash": "e21c90d2b781098165ceaea8e23f87376556e8b8fca0fee3ed5d5416506bb9ac",
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {
-      "hash": "99b2afe08b02193a66628e0f7a197bcb8747e975f743dafbe9e09543d6ddde24",
+      "hash": "5c5b9ff4f0cc657570699c120e8028b87ae95f00a318ccd9349fabc800dee10a",
       "path": "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json"
     },
     "ipfs/credit/credit.schema.json": {

--- a/schemas/schema-hashes.json
+++ b/schemas/schema-hashes.json
@@ -22,7 +22,7 @@
       "path": "ipfs/gas-id/gas-id.schema.json"
     },
     "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json": {
-      "hash": "343a22f6bd51a89b8a6ca83c5136938a2bd3e3c1b42645d05216476085d28d06",
+      "hash": "882cdddf6158a56bae8b41b3cd07db27a9e6a37efbf98c2a637ec2a8a8e38c5a",
       "path": "ipfs/credit-retirement-receipt/credit-retirement-receipt.schema.json"
     },
     "ipfs/credit-purchase-receipt/credit-purchase-receipt.schema.json": {

--- a/scripts/example-content/emitters/credit-purchase-receipt.ts
+++ b/scripts/example-content/emitters/credit-purchase-receipt.ts
@@ -172,6 +172,7 @@ export function emitCreditPurchaseReceiptExample(): Record<string, unknown> {
           type: 'GasID',
           token_id: story.gasID.tokenId,
           total_amount: 10,
+          purchased_amount: 3,
           credit_slug: story.credit.slug,
           external_id: 'd2a7f8e4-9c61-4e35-b8f2-a5c9e7d1b4f6',
           external_url:
@@ -200,6 +201,7 @@ export function emitCreditPurchaseReceiptExample(): Record<string, unknown> {
           type: 'RecycledID',
           token_id: story.recycledID.tokenId,
           total_amount: 6,
+          purchased_amount: 2,
           credit_slug: 'biowaste',
           external_id: 'f47ac10b-58cc-4372-a567-0e02b2c3d489',
           external_url:
@@ -228,6 +230,7 @@ export function emitCreditPurchaseReceiptExample(): Record<string, unknown> {
           type: 'RecycledID',
           token_id: '890',
           total_amount: 8,
+          purchased_amount: 3.5,
           credit_slug: 'biowaste',
           external_id: '0f1e2d3c-4b5a-4d78-8c12-3456789abcde',
           external_url:

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
@@ -209,6 +209,54 @@ describe('CreditPurchaseReceiptDataSchema', () => {
     });
   });
 
+  it('accepts no-collection variant (data.collections empty + every cert.collections empty)', () => {
+    expectSchemaValid(schema, () => {
+      const data = structuredClone(baseData);
+      data.collections = [];
+      data.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      Reflect.deleteProperty(
+        data as Record<string, unknown>,
+        'retirement_receipt',
+      );
+      return data;
+    });
+  });
+
+  it('accepts mixed-mode receipt (some certs with collections, some without)', () => {
+    expectSchemaValid(schema, () => {
+      const data = structuredClone(baseData);
+      data.certificates.slice(1).forEach((cert) => {
+        cert.collections = [];
+      });
+      const stillReferenced = new Set<string>(
+        data.certificates.flatMap((cert) =>
+          cert.collections.map((c) => c.slug),
+        ),
+      );
+      data.collections = data.collections.filter((c) =>
+        stillReferenced.has(c.slug),
+      );
+      const totalRetired = data.certificates.reduce(
+        (sum, cert) =>
+          sum +
+          cert.collections.reduce(
+            (s, col) => s + Number(col.retired_amount),
+            0,
+          ),
+        0,
+      );
+      if (totalRetired === 0) {
+        Reflect.deleteProperty(
+          data as Record<string, unknown>,
+          'retirement_receipt',
+        );
+      }
+      return data;
+    });
+  });
+
   it('rejects summary.total_credits === 0', () => {
     expectSchemaInvalid(schema, baseData, (invalid) => {
       invalid.summary.total_credits = 0;

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
@@ -288,6 +288,20 @@ describe('CreditPurchaseReceiptDataSchema', () => {
     });
   });
 
+  it('rejects when data.collections contains a slug not referenced by any certificate', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      (invalid.collections as unknown as Record<string, unknown>[]).push({
+        slug: 'phantom-collection',
+        name: 'Phantom Collection',
+        external_id: 'aa1bb2cc-3d4e-4f56-7890-1234567890ab',
+        external_url:
+          'https://explore.carrot.eco/collection/phantom-collection',
+        ipfs_uri:
+          'ipfs://bafybeiaysiqlz2rcdjfbh264l4d7f5szszw7vvr2wxwb62xtx4tqhy4gmy',
+      });
+    });
+  });
+
   it('rejects no-collection receipt when certificate.purchased_amount exceeds total_amount', () => {
     expectSchemaInvalid(schema, baseData, (invalid) => {
       invalid.collections = [];

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
@@ -185,4 +185,13 @@ describe('CreditPurchaseReceiptDataSchema', () => {
       };
     });
   });
+
+  it('requires purchased_amount on every certificate', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      Reflect.deleteProperty(
+        invalid.certificates[0] as Record<string, unknown>,
+        'purchased_amount',
+      );
+    });
+  });
 });

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
@@ -194,4 +194,35 @@ describe('CreditPurchaseReceiptDataSchema', () => {
       );
     });
   });
+
+  it('rejects when certificate.purchased_amount does not match sum of collections.purchased_amount', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      invalid.certificates[0].purchased_amount =
+        invalid.certificates[0].purchased_amount + 1;
+    });
+  });
+
+  it('rejects when certificate.purchased_amount exceeds certificate.total_amount', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      invalid.certificates[0].purchased_amount =
+        invalid.certificates[0].total_amount + 1;
+    });
+  });
+
+  it('rejects summary.total_credits === 0', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      invalid.summary.total_credits = 0;
+      invalid.certificates.forEach((cert) => {
+        cert.purchased_amount = 0;
+        cert.collections.forEach((col) => {
+          col.purchased_amount = 0;
+          col.retired_amount = 0;
+        });
+      });
+      Reflect.deleteProperty(
+        invalid as Record<string, unknown>,
+        'retirement_receipt',
+      );
+    });
+  });
 });

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
@@ -291,11 +291,10 @@ describe('CreditPurchaseReceiptDataSchema', () => {
   it('rejects when data.collections contains a slug not referenced by any certificate', () => {
     expectSchemaInvalid(schema, baseData, (invalid) => {
       (invalid.collections as unknown as Record<string, unknown>[]).push({
-        slug: 'phantom-collection',
-        name: 'Phantom Collection',
+        slug: 'bold-innovators',
+        name: 'BOLD Innovators',
         external_id: 'aa1bb2cc-3d4e-4f56-7890-1234567890ab',
-        external_url:
-          'https://explore.carrot.eco/collection/phantom-collection',
+        external_url: 'https://explore.carrot.eco/collection/bold-innovators',
         ipfs_uri:
           'ipfs://bafybeiaysiqlz2rcdjfbh264l4d7f5szszw7vvr2wxwb62xtx4tqhy4gmy',
       });

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.data.schema.spec.ts
@@ -273,4 +273,33 @@ describe('CreditPurchaseReceiptDataSchema', () => {
       );
     });
   });
+
+  it('rejects no-collection receipt when summary.total_credits does not match sum of certificates.purchased_amount', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      invalid.collections = [];
+      invalid.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      invalid.summary.total_credits = invalid.summary.total_credits + 1;
+      Reflect.deleteProperty(
+        invalid as Record<string, unknown>,
+        'retirement_receipt',
+      );
+    });
+  });
+
+  it('rejects no-collection receipt when certificate.purchased_amount exceeds total_amount', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      invalid.collections = [];
+      invalid.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      invalid.certificates[0].purchased_amount =
+        invalid.certificates[0].total_amount + 1;
+      Reflect.deleteProperty(
+        invalid as Record<string, unknown>,
+        'retirement_receipt',
+      );
+    });
+  });
 });

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.schema.spec.ts
@@ -220,6 +220,15 @@ describe('CreditPurchaseReceiptIpfsSchema', () => {
         withUnusedCredit.data.certificates.filter(
           (cert) => cert.credit_slug !== biowasteCredit.slug,
         );
+      const referencedSlugs = new Set(
+        withUnusedCredit.data.certificates.flatMap((cert) =>
+          cert.collections.map((col) => col.slug),
+        ),
+      );
+      withUnusedCredit.data.collections =
+        withUnusedCredit.data.collections.filter((col) =>
+          referencedSlugs.has(col.slug),
+        );
       const biowasteAttribute = withUnusedCredit.attributes.find(
         (attr) => attr.trait_type === 'C-BIOW',
       );

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.schema.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import {
   expectIssuesContain,
+  expectSchemaInvalid,
   expectSchemaInvalidWithout,
   expectSchemaTyped,
   expectSchemaValid,
@@ -271,6 +272,25 @@ describe('CreditPurchaseReceiptIpfsSchema', () => {
         'retirement_receipt',
       );
       return value;
+    });
+  });
+
+  it('rejects no-collection NFT receipt when per-symbol attribute does not match purchased_amount', () => {
+    expectSchemaInvalid(schema, base, (invalid) => {
+      invalid.data.collections = [];
+      invalid.data.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      Reflect.deleteProperty(
+        invalid.data as Record<string, unknown>,
+        'retirement_receipt',
+      );
+      const firstSymbolAttr = invalid.attributes.find(
+        (a) => a.trait_type === invalid.data.credits[0].symbol,
+      );
+      if (firstSymbolAttr) {
+        firstSymbolAttr.value = Number(firstSymbolAttr.value) + 1;
+      }
     });
   });
 

--- a/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.schema.spec.ts
+++ b/src/credit-purchase-receipt/__tests__/credit-purchase-receipt.schema.spec.ts
@@ -259,6 +259,21 @@ describe('CreditPurchaseReceiptIpfsSchema', () => {
     });
   });
 
+  it('accepts no-collection NFT receipt with per-symbol attributes from purchased_amount', () => {
+    expectSchemaValid(schema, () => {
+      const value = structuredClone(base);
+      value.data.collections = [];
+      value.data.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      Reflect.deleteProperty(
+        value.data as Record<string, unknown>,
+        'retirement_receipt',
+      );
+      return value;
+    });
+  });
+
   it('rejects name with mismatched token_id', () => {
     expectIssuesContain(schema, () => {
       const next = structuredClone(base);

--- a/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
+++ b/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
@@ -150,6 +150,7 @@ export const CreditPurchaseReceiptDataSchema = z
     const collectionSlugs = new Set<string>(
       data.collections.map((collection) => String(collection.slug)),
     );
+    const referencedCollectionSlugs = new Set<string>();
     const creditSlugs = new Set<string>(
       data.credits.map((credit) => String(credit.slug)),
     );
@@ -175,6 +176,7 @@ export const CreditPurchaseReceiptDataSchema = z
       });
 
       certificate.collections.forEach((collectionItem, collectionIndex) => {
+        referencedCollectionSlugs.add(String(collectionItem.slug));
         if (collectionItem.retired_amount > collectionItem.purchased_amount) {
           ctx.addIssue({
             code: 'custom',
@@ -226,6 +228,17 @@ export const CreditPurchaseReceiptDataSchema = z
     const certificateCollectionRetiredTotal = Array.from(
       collectionRetiredTotalsBySlug.values(),
     ).reduce((sum, amount) => sum + amount, 0);
+
+    data.collections.forEach((collection, collectionIndex) => {
+      if (!referencedCollectionSlugs.has(String(collection.slug))) {
+        ctx.addIssue({
+          code: 'custom',
+          message:
+            'collections must only include slugs referenced by certificates[].collections',
+          path: ['collections', collectionIndex, 'slug'],
+        });
+      }
+    });
 
     validateTotalMatches({
       ctx,

--- a/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
+++ b/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
@@ -108,13 +108,11 @@ export const CreditPurchaseReceiptDataSchema = z
       CreditPurchaseReceiptCollectionSchema,
       (collection) => collection.slug,
       'Collection slugs must be unique',
-    )
-      .min(1)
-      .meta({
-        title: 'Collections',
-        description:
-          'Impact collections referenced by this purchase, each identified by a unique slug',
-      }),
+    ).meta({
+      title: 'Collections',
+      description:
+        'Impact collections referenced by this purchase, each identified by a unique slug. May be empty when no certificate is assigned to a collection.',
+    }),
     credits: uniqueBy(
       CreditPurchaseReceiptCreditSchema,
       (credit) => credit.slug,

--- a/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
+++ b/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
@@ -15,6 +15,7 @@ import {
   CreditRetirementReceiptReferenceSchema,
 } from '../shared';
 import {
+  CreditAmountSchema,
   CreditTokenSlugSchema,
   EthereumAddressSchema,
   Sha256HashSchema,
@@ -70,17 +71,20 @@ const CreditPurchaseReceiptCertificateSchema =
     credit_slug: CreditTokenSlugSchema.meta({
       description: 'Slug of the credit type for this certificate',
     }),
+    purchased_amount: CreditAmountSchema.meta({
+      title: 'Certificate Purchased Amount',
+      description:
+        'Total credits purchased from this certificate. Authoritative source for receipt totals; cross-checked against sum(collections[].purchased_amount) when collections are non-empty.',
+    }),
     collections: uniqueBy(
       CertificateCollectionItemPurchaseSchema,
       (item) => item.slug,
       'Collection slugs within certificate collections must be unique',
-    )
-      .min(1)
-      .meta({
-        title: 'Certificate Collections',
-        description:
-          'Collections associated with this certificate, each with purchased and retired amounts',
-      }),
+    ).meta({
+      title: 'Certificate Collections',
+      description:
+        'Collections associated with this certificate, each with purchased and retired amounts. May be empty when this certificate is not assigned to any collection.',
+    }),
   }).meta({
     title: 'Certificate',
     description: 'Certificate associated with the purchase',

--- a/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
+++ b/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
@@ -147,14 +147,6 @@ export const CreditPurchaseReceiptDataSchema = z
         'summary.total_certificates must equal the number of certificates',
     });
 
-    if (data.summary.total_credits === 0) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'summary.total_credits must be greater than 0',
-        path: ['summary', 'total_credits'],
-      });
-    }
-
     const collectionSlugs = new Set<string>(
       data.collections.map((collection) => String(collection.slug)),
     );
@@ -162,9 +154,6 @@ export const CreditPurchaseReceiptDataSchema = z
       data.credits.map((credit) => String(credit.slug)),
     );
 
-    const creditPurchaseTotalsBySlug = new Map<string, number>();
-    const creditRetiredTotalsBySlug = new Map<string, number>();
-    const collectionPurchasedTotalsBySlug = new Map<string, number>();
     const collectionRetiredTotalsBySlug = new Map<string, number>();
     let totalCreditsFromCertificates = 0;
 
@@ -177,7 +166,6 @@ export const CreditPurchaseReceiptDataSchema = z
       });
 
       let certificatePurchasedTotal = 0;
-      let certificateRetiredTotal = 0;
 
       validateCertificateCollectionSlugs({
         ctx,
@@ -203,13 +191,7 @@ export const CreditPurchaseReceiptDataSchema = z
         }
 
         certificatePurchasedTotal += Number(collectionItem.purchased_amount);
-        certificateRetiredTotal += Number(collectionItem.retired_amount);
 
-        collectionPurchasedTotalsBySlug.set(
-          collectionItem.slug,
-          (collectionPurchasedTotalsBySlug.get(collectionItem.slug) ?? 0) +
-            Number(collectionItem.purchased_amount),
-        );
         collectionRetiredTotalsBySlug.set(
           collectionItem.slug,
           (collectionRetiredTotalsBySlug.get(collectionItem.slug) ?? 0) +
@@ -239,17 +221,6 @@ export const CreditPurchaseReceiptDataSchema = z
       }
 
       totalCreditsFromCertificates += Number(certificate.purchased_amount);
-
-      creditPurchaseTotalsBySlug.set(
-        String(certificate.credit_slug),
-        (creditPurchaseTotalsBySlug.get(certificate.credit_slug) ?? 0) +
-          certificatePurchasedTotal,
-      );
-      creditRetiredTotalsBySlug.set(
-        String(certificate.credit_slug),
-        (creditRetiredTotalsBySlug.get(certificate.credit_slug) ?? 0) +
-          certificateRetiredTotal,
-      );
     });
 
     const certificateCollectionRetiredTotal = Array.from(

--- a/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
+++ b/src/credit-purchase-receipt/credit-purchase-receipt.data.schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import {
   uniqueBy,
+  nearlyEqual,
   CreditPurchaseReceiptSummarySchema,
   ReceiptIdentitySchema,
   CertificateCollectionItemPurchaseSchema,
@@ -148,6 +149,14 @@ export const CreditPurchaseReceiptDataSchema = z
         'summary.total_certificates must equal the number of certificates',
     });
 
+    if (data.summary.total_credits === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'summary.total_credits must be greater than 0',
+        path: ['summary', 'total_credits'],
+      });
+    }
+
     const collectionSlugs = new Set<string>(
       data.collections.map((collection) => String(collection.slug)),
     );
@@ -210,16 +219,28 @@ export const CreditPurchaseReceiptDataSchema = z
         );
       });
 
-      if (certificatePurchasedTotal > certificate.total_amount) {
+      if (certificate.purchased_amount > certificate.total_amount) {
         ctx.addIssue({
           code: 'custom',
           message:
-            'Sum of certificate.collections[].purchased_amount cannot exceed certificate.total_amount',
-          path: ['certificates', index],
+            'certificate.purchased_amount cannot exceed certificate.total_amount',
+          path: ['certificates', index, 'purchased_amount'],
         });
       }
 
-      totalCreditsFromCertificates += certificatePurchasedTotal;
+      if (
+        certificate.collections.length > 0 &&
+        !nearlyEqual(certificatePurchasedTotal, certificate.purchased_amount)
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          message:
+            'certificate.purchased_amount must equal sum of collections[].purchased_amount when collections are present',
+          path: ['certificates', index, 'purchased_amount'],
+        });
+      }
+
+      totalCreditsFromCertificates += Number(certificate.purchased_amount);
 
       creditPurchaseTotalsBySlug.set(
         String(certificate.credit_slug),
@@ -243,7 +264,7 @@ export const CreditPurchaseReceiptDataSchema = z
       expectedTotal: data.summary.total_credits,
       path: ['summary', 'total_credits'],
       message:
-        'summary.total_credits must equal sum of certificate.collections[].purchased_amount',
+        'summary.total_credits must equal sum of certificates[].purchased_amount',
     });
 
     validateRetirementReceiptRequirement({

--- a/src/credit-purchase-receipt/credit-purchase-receipt.schema.ts
+++ b/src/credit-purchase-receipt/credit-purchase-receipt.schema.ts
@@ -18,7 +18,7 @@ import { CreditPurchaseReceiptAttributesSchema } from './credit-purchase-receipt
 export const CreditPurchaseReceiptIpfsSchemaMeta = {
   title: 'CreditPurchaseReceipt NFT IPFS Record',
   description:
-    'Complete CreditPurchaseReceipt NFT IPFS record including purchase summary, buyer details, credit breakdowns, certificate allocations, and NFT display attributes',
+    'Complete CreditPurchaseReceipt NFT IPFS record including purchase summary, buyer details, credit breakdowns, certificate allocations, and NFT display attributes. Supports both collection-assigned and no-collection variants.',
   $id: buildSchemaUrl(
     'credit-purchase-receipt/credit-purchase-receipt.schema.json',
   ),
@@ -179,14 +179,10 @@ export const CreditPurchaseReceiptIpfsSchema = NftIpfsSchema.safeExtend({
         });
         return;
       }
-      const certificatePurchasedTotal = certificate.collections.reduce(
-        (sum, collection) => sum + Number(collection.purchased_amount),
-        0,
-      );
       const currentTotal = creditTotalsBySymbol.get(credit.symbol) ?? 0;
       creditTotalsBySymbol.set(
         credit.symbol,
-        currentTotal + certificatePurchasedTotal,
+        currentTotal + Number(certificate.purchased_amount),
       );
     });
 
@@ -202,7 +198,7 @@ export const CreditPurchaseReceiptIpfsSchema = NftIpfsSchema.safeExtend({
       } else if (Number(attribute.value) !== expectedTotal) {
         ctx.addIssue({
           code: 'custom',
-          message: `Attribute for credit symbol ${credit.symbol} must match sum of certificate.collections[].purchased_amount for the credit symbol`,
+          message: `Attribute for credit symbol ${credit.symbol} must match sum of certificates[].purchased_amount for the credit symbol`,
           path: ['attributes'],
         });
       }

--- a/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.data.schema.spec.ts
+++ b/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.data.schema.spec.ts
@@ -194,4 +194,28 @@ describe('CreditRetirementReceiptDataSchema', () => {
       });
     });
   });
+
+  it('accepts no-collection retirement variant (data.collections empty + every cert.collections empty)', () => {
+    expectSchemaValid(schema, () => {
+      const data = structuredClone(baseData);
+      data.collections = [];
+      data.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      return data;
+    });
+  });
+
+  it('rejects summary.total_credits_retired === 0', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      invalid.collections = [];
+      invalid.summary.total_credits_retired = 0;
+      invalid.certificates.forEach((cert) => {
+        cert.collections = [];
+        cert.credits_retired.forEach((cr) => {
+          cr.amount = 0;
+        });
+      });
+    });
+  });
 });

--- a/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.data.schema.spec.ts
+++ b/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.data.schema.spec.ts
@@ -206,6 +206,57 @@ describe('CreditRetirementReceiptDataSchema', () => {
     });
   });
 
+  it('rejects no-collection retirement when summary.total_credits_retired does not match sum of credits_retired amounts', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      invalid.collections = [];
+      invalid.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      invalid.summary.total_credits_retired =
+        invalid.summary.total_credits_retired + 1;
+    });
+  });
+
+  it('rejects no-collection retirement when sum of credits_retired exceeds certificate.total_amount', () => {
+    expectSchemaInvalid(schema, baseData, (invalid) => {
+      invalid.collections = [];
+      invalid.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      const cert = invalid.certificates[0];
+      const inflated = cert.total_amount + 5;
+      cert.credits_retired[0].amount = inflated;
+      invalid.summary.total_credits_retired =
+        inflated +
+        invalid.certificates
+          .slice(1)
+          .reduce(
+            (s, c) =>
+              s +
+              c.credits_retired.reduce((cs, cr) => cs + Number(cr.amount), 0),
+            0,
+          );
+    });
+  });
+
+  it('accepts mixed-mode retirement (some certs with collections, some without)', () => {
+    expectSchemaValid(schema, () => {
+      const data = structuredClone(baseData);
+      data.certificates.slice(1).forEach((cert) => {
+        cert.collections = [];
+      });
+      const stillReferenced = new Set<string>(
+        data.certificates.flatMap((cert) =>
+          cert.collections.map((c) => c.slug),
+        ),
+      );
+      data.collections = data.collections.filter((c) =>
+        stillReferenced.has(c.slug),
+      );
+      return data;
+    });
+  });
+
   it('rejects summary.total_credits_retired === 0', () => {
     expectSchemaInvalid(schema, baseData, (invalid) => {
       invalid.collections = [];

--- a/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.schema.spec.ts
+++ b/src/credit-retirement-receipt/__tests__/credit-retirement-receipt.schema.spec.ts
@@ -258,6 +258,17 @@ describe('CreditRetirementReceiptIpfsSchema', () => {
     });
   });
 
+  it('accepts no-collection NFT retirement receipt', () => {
+    expectSchemaValid(schema, () => {
+      const value = structuredClone(base);
+      value.data.collections = [];
+      value.data.certificates.forEach((cert) => {
+        cert.collections = [];
+      });
+      return value;
+    });
+  });
+
   it('allows purchase_receipt to be omitted', () => {
     expectSchemaValid(schema, () => {
       const withoutPurchase = structuredClone(base);

--- a/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
+++ b/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
@@ -213,14 +213,6 @@ export const CreditRetirementReceiptDataSchema = z
         'summary.total_certificates must equal the number of certificates',
     });
 
-    if (data.summary.total_credits_retired === 0) {
-      ctx.addIssue({
-        code: 'custom',
-        message: 'summary.total_credits_retired must be greater than 0',
-        path: ['summary', 'total_credits_retired'],
-      });
-    }
-
     const creditTotalsBySymbol = new Map<string, number>();
     const collectionRetiredTotalsBySlug = new Map<string, number>();
     let totalRetiredFromCertificates = 0;
@@ -240,6 +232,20 @@ export const CreditRetirementReceiptDataSchema = z
         });
       }
 
+      const creditsRetiredTotal = certificate.credits_retired.reduce(
+        (sum, credit) => sum + Number(credit.amount),
+        0,
+      );
+
+      if (creditsRetiredTotal > certificate.total_amount) {
+        ctx.addIssue({
+          code: 'custom',
+          message:
+            'Sum of certificate.credits_retired[].amount cannot exceed certificate.total_amount',
+          path: ['certificates', index, 'credits_retired'],
+        });
+      }
+
       validateCertificateCollectionSlugs({
         ctx,
         certificateCollections: certificate.collections,
@@ -254,11 +260,6 @@ export const CreditRetirementReceiptDataSchema = z
             Number(collectionItem.retired_amount),
         );
       });
-
-      const creditsRetiredTotal = certificate.credits_retired.reduce(
-        (sum, credit) => sum + Number(credit.amount),
-        0,
-      );
 
       if (
         certificate.collections.length > 0 &&

--- a/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
+++ b/src/credit-retirement-receipt/credit-retirement-receipt.data.schema.ts
@@ -128,13 +128,11 @@ const CreditRetirementReceiptCertificateSchema =
       CertificateCollectionItemRetirementSchema,
       (item) => item.slug,
       'Collection slugs within certificate collections must be unique',
-    )
-      .min(1)
-      .meta({
-        title: 'Certificate Collections',
-        description:
-          'Collections associated with this certificate, each with retired amounts',
-      }),
+    ).meta({
+      title: 'Certificate Collections',
+      description:
+        'Collections associated with this certificate, each with retired amounts. May be empty when this certificate is not assigned to any collection.',
+    }),
     credits_retired: uniqueBy(
       CreditRetirementReceiptCertificateCreditSchema,
       (credit) => credit.credit_symbol,
@@ -163,13 +161,11 @@ export const CreditRetirementReceiptDataSchema = z
       CreditRetirementReceiptCollectionSchema,
       (collection) => collection.slug,
       'Collection slugs must be unique',
-    )
-      .min(1)
-      .meta({
-        title: 'Collections',
-        description:
-          'Impact collections referenced by this retirement, each identified by a unique slug',
-      }),
+    ).meta({
+      title: 'Collections',
+      description:
+        'Impact collections referenced by this retirement, each identified by a unique slug. May be empty when no certificate is assigned to a collection.',
+    }),
     credits: uniqueBy(
       CreditRetirementReceiptCreditSchema,
       (credit) => credit.slug,
@@ -217,6 +213,14 @@ export const CreditRetirementReceiptDataSchema = z
         'summary.total_certificates must equal the number of certificates',
     });
 
+    if (data.summary.total_credits_retired === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'summary.total_credits_retired must be greater than 0',
+        path: ['summary', 'total_credits_retired'],
+      });
+    }
+
     const creditTotalsBySymbol = new Map<string, number>();
     const collectionRetiredTotalsBySlug = new Map<string, number>();
     let totalRetiredFromCertificates = 0;
@@ -257,6 +261,7 @@ export const CreditRetirementReceiptDataSchema = z
       );
 
       if (
+        certificate.collections.length > 0 &&
         !nearlyEqual(creditsRetiredTotal, certificateCollectionRetiredTotal)
       ) {
         ctx.addIssue({
@@ -320,7 +325,7 @@ export const CreditRetirementReceiptDataSchema = z
         );
       });
 
-      totalRetiredFromCertificates += certificateCollectionRetiredTotal;
+      totalRetiredFromCertificates += creditsRetiredTotal;
     });
 
     validateTotalMatches({
@@ -329,14 +334,16 @@ export const CreditRetirementReceiptDataSchema = z
       expectedTotal: data.summary.total_credits_retired,
       path: ['summary', 'total_credits_retired'],
       message:
-        'summary.total_credits_retired must equal sum of certificate.collections[].retired_amount',
+        'summary.total_credits_retired must equal sum of certificates[].credits_retired[].amount',
     });
 
-    validateCollectionsHaveRetiredAmounts({
-      ctx,
-      collections: data.collections,
-      retiredTotalsBySlug: collectionRetiredTotalsBySlug,
-    });
+    if (data.collections.length > 0) {
+      validateCollectionsHaveRetiredAmounts({
+        ctx,
+        collections: data.collections,
+        retiredTotalsBySlug: collectionRetiredTotalsBySlug,
+      });
+    }
   })
   .meta({
     title: 'Credit Retirement Receipt Data',

--- a/src/credit-retirement-receipt/credit-retirement-receipt.schema.ts
+++ b/src/credit-retirement-receipt/credit-retirement-receipt.schema.ts
@@ -18,7 +18,7 @@ import { CreditRetirementReceiptAttributesSchema } from './credit-retirement-rec
 export const CreditRetirementReceiptIpfsSchemaMeta = {
   title: 'CreditRetirementReceipt NFT IPFS Record',
   description:
-    'Complete CreditRetirementReceipt NFT IPFS record including retirement summary, beneficiary and credit holder details (identity optional), credit breakdowns, certificate allocations, and NFT display attributes',
+    'Complete CreditRetirementReceipt NFT IPFS record including retirement summary, beneficiary and credit holder details (identity optional), credit breakdowns, certificate allocations, and NFT display attributes. Supports both collection-assigned and no-collection variants.',
   $id: buildSchemaUrl(
     'credit-retirement-receipt/credit-retirement-receipt.schema.json',
   ),

--- a/src/shared/schemas/receipt/receipt.schemas.ts
+++ b/src/shared/schemas/receipt/receipt.schemas.ts
@@ -30,10 +30,10 @@ export const CreditPurchaseReceiptSummarySchema = SummaryBaseSchema.safeExtend({
     title: 'Total Amount (USDC)',
     description: 'Total amount paid in USDC stablecoin for the credit purchase',
   }),
-  total_credits: CreditAmountSchema.meta({
+  total_credits: CreditAmountSchema.gt(0).meta({
     title: 'Total Credits',
     description:
-      'Total number of environmental impact credits purchased in this transaction',
+      'Total number of environmental impact credits purchased in this transaction. Must be greater than 0.',
   }),
   purchased_at: IsoDateTimeSchema.meta({
     title: 'Purchased At',
@@ -50,10 +50,10 @@ export type CreditPurchaseReceiptSummary = z.infer<
 
 export const CreditRetirementReceiptSummarySchema =
   SummaryBaseSchema.safeExtend({
-    total_credits_retired: CreditAmountSchema.meta({
+    total_credits_retired: CreditAmountSchema.gt(0).meta({
       title: 'Total Credits Retired',
       description:
-        'Total number of environmental impact credits permanently retired (removed from circulation)',
+        'Total number of environmental impact credits permanently retired (removed from circulation). Must be greater than 0.',
     }),
     retired_at: IsoDateTimeSchema.meta({
       title: 'Retired At',


### PR DESCRIPTION
## Summary

- Adds required scalar `purchased_amount` to `CreditPurchaseReceipt` certificates as the authoritative source for receipt totals.
- Drops `.min(1)` on `data.collections` and `certificate.collections` in both `CreditPurchaseReceipt` and `CreditRetirementReceipt` schemas.
- Re-routes `summary.total_credits[_retired]` and per-credit-symbol NFT attribute checks through collection-independent sources (`purchased_amount` for purchase, existing `credits_retired[]` for retirement).
- Per-cert flexible mixed mode: collection ↔ scalar cross-check enforced per certificate when that certificate has non-empty `collections`.
- New explicit `> 0` rule on `summary.total_credits` and `summary.total_credits_retired` (primitive `CreditAmountSchema` allowed 0; degenerate receipts now rejected).
- Major bump to **2.0.0** via semantic-release (breaking commit marker on `5527e77`; new required `purchased_amount` field on purchase certs).

## Design

Hybrid Option B+C — scalar `purchased_amount` field on purchase certs (no discriminator). Spec at `docs/superpowers/specs/2026-05-06-no-collection-credit-receipts-design.md`. Plan at `docs/superpowers/plans/2026-05-06-no-collection-credit-receipts.md`.

## Smaug migration

Downstream `smaug` must:
- Emit `data.certificates[].purchased_amount` on every purchase certificate (= sum of `collections[].purchased_amount` when collections present, otherwise the total credits purchased from that certificate).
- Optionally emit `data.collections: []` and per-cert `collections: []` for the no-collection variant.

No discriminator field required. Smaug PR is blocked on this release.

## Test plan

- [x] With-collection happy path (existing, unchanged)
- [x] No-collection happy path (purchase + retirement, data + NFT layers)
- [x] Mixed-mode per-cert flexible (purchase)
- [x] Cross-check failure: cert.purchased_amount ≠ sum of collection sums
- [x] Missing required `purchased_amount` rejected
- [x] `purchased_amount > total_amount` rejected
- [x] Per-symbol attribute mismatch rejected (purchase + retirement)
- [x] Zero-credits receipt rejected (purchase + retirement)
- [x] 100% coverage maintained (668 tests across 38 files)
- [x] Pipeline: generate → hash → update-examples → validate-schemas → validate-examples → verify-schema-versions
- [x] `pnpm check` clean
- [x] `pnpm build` clean; `purchased_amount` exported in `dist/index.d.ts`